### PR TITLE
fix: login modal not showing up after closing

### DIFF
--- a/src/components/layout/navbar/profileDropdown.tsx
+++ b/src/components/layout/navbar/profileDropdown.tsx
@@ -29,6 +29,11 @@ const ProfileDropdown = () => {
           <DropdownMenuItem>
             <div
               onClick={() => {
+								if (window.location.pathname === '/login') {
+									window.location.reload();
+									return;
+								}
+
                 router.push('api/auth/signin');
               }}
               className='flex w-full items-center gap-2'


### PR DESCRIPTION
### 📃 Description
Fixes #245  login modal issue.

**Current Behavior**
The user is unable to open the login modal after closing it

**Expected behavior**
After closing the modal user should be able to open the login modal again.

**Steps to reproduce**
1. Open home page.
2. Click on login
3. Close the login modal
4. Click on login again.


**Related Tickets & Documents**

Fixes # (issue)

**What type of PR is this? (check all applicable)**

- [ ] 💡 Feature
- [x] 🐛 Bug Fix
- [ ] 📃 Documentation Update
- [ ] 🎨 Style Changes
- [ ] 💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test

### 🔰 Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### ❓ How Has This Been Tested?
Steps to test
1. Open home page.
2. Click on login
3. Close the login modal
4. Click on login again.

### 🔰 Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
