### PR TITLE
feat: add cache workflow to main branch

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,36 @@
+name: Linter
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+
+      - name: Cache node_modules
+        id: cache-npm
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: npm list
+
+      - name: Install dependencies
+        run: npm install


### PR DESCRIPTION
## Description
This PR creates a cache workflow to create dependency cache.

## How this works
1. Whenever a code is pushed/branch is merged to main
2. Checks if dependency cache exist by creating a hash based on package-lock.json
3. a. If the cache is found will safely exit
    b. If cache is not found, it will create the cache and exit.

## Why this action
Earlier action added creates a cache every time for a particular PR request, this action prevents that as the PR will find the cache in the `main` branch path