### PR TITLE
feat(ui): add unfollow button in following tab

### DIFF
--- a/src/components/user/dialogs/ConnectionsDialog.tsx
+++ b/src/components/user/dialogs/ConnectionsDialog.tsx
@@ -14,6 +14,8 @@ import {
   useGetFollowing,
 } from '@/hooks/user/useUserConnections';
 
+import { FollowButton } from '../buttons/followButton';
+
 const ConnectionCard = ({
   first_name,
   last_name,
@@ -121,12 +123,18 @@ export const ConnectionsDialog = ({
                   {following?.users ? (
                     following?.users.map((following) => {
                       return (
-                        <ConnectionCard
-                          key={following?.username}
-                          first_name={following.first_name}
-                          last_name={following.last_name}
-                          username={following.username}
-                        />
+                        <>
+                          <div className='flex justify-between items-center'>
+                            {' '}
+                            <ConnectionCard
+                              key={following?.username}
+                              first_name={following.first_name}
+                              last_name={following.last_name}
+                              username={following.username}
+                            />
+                            <FollowButton username={following.username} />
+                          </div>
+                        </>
                       );
                     })
                   ) : (


### PR DESCRIPTION
### 📌 Summary  
This PR adds an **Unfollow button** in the **Following tab** inside the user profile page. Now, users can directly unfollow others from the **Following list** instead of visiting individual profiles.  

### ✨ Changes Made  
- Added the **Unfollow button** next to each user in the **Following** tab.  
- Integrated the `FollowButton.tsx` to handle both **Follow** and **Unfollow** actions.  
- Updated the `ConnectionsDialog.tsx` to ensure the button appears properly. 

### 🛠️ Issue Reference  
Closes #283  
