### PR TITLE
[Hotfix]: fix: update username error

### DIFF
--- a/src/app/settings/components/account/Username.tsx
+++ b/src/app/settings/components/account/Username.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-
 import { Loader } from '@/components/loader';
 import { Button } from '@/components/ui/button';
 import {
@@ -17,12 +15,12 @@ import { updateUsername as updateUsernameSchema } from '@/lib/schema/settings';
 import { IUser } from '@/services/models/user';
 import { updateUserName } from '@/services/user/user';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 export const Username = ({ data }: { data: IUser }) => {
-  const router = useRouter();
+  const queryClient = useQueryClient();
 
   const form = useForm<z.infer<typeof updateUsernameSchema>>({
     resolver: zodResolver(updateUsernameSchema),
@@ -34,6 +32,8 @@ export const Username = ({ data }: { data: IUser }) => {
   const mutation = useMutation({
     mutationFn: updateUserName,
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['auth'] });
+
       form.reset();
       toast({
         variant: 'success',

--- a/src/components/user/dialogs/UpdateUsernameDialog.tsx
+++ b/src/components/user/dialogs/UpdateUsernameDialog.tsx
@@ -21,10 +21,11 @@ import {
 import { Input } from '@/components/ui/input';
 import { toast } from '@/components/ui/use-toast';
 import { updateUsername } from '@/lib/schema/settings';
+import { User } from '@/services/models/user';
 import { GetPublicUserProfileApiResponse } from '@/services/profile/userApiTypes';
 import { updateUserName } from '@/services/user/user';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -34,6 +35,7 @@ export const UpdateUsernameDialog = ({
   user?: GetPublicUserProfileApiResponse;
 }) => {
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const form = useForm<z.infer<typeof updateUsername>>({
     resolver: zodResolver(updateUsername),
@@ -45,13 +47,17 @@ export const UpdateUsernameDialog = ({
   const mutation = useMutation({
     mutationFn: updateUserName,
     onSuccess: (data) => {
+      const user = new User(data);
+      console.log('-->', user);
+      queryClient.invalidateQueries({ queryKey: ['auth'] });
+
       form.reset();
-      router.push(`/${data.username}`);
       toast({
         variant: 'success',
         title: 'Success',
         description: 'Username updated successfully.',
       });
+      router.push(`/${user.username}`);
     },
     onError: (err) => {
       toast({


### PR DESCRIPTION
## Description
On updating username the sites doesn't properly update the session of the user immediately and on updating via dialog, the site doesn't redirect to updated username. This PR fixes that issue.


## Steps to reproduce
Settings page flow
1. Go to Settings page
2. Select Account
3. Update username
Notice the placeholder is still the same and doesn't gets updated till the site is reloaded manually

Update username dialog flow
1. Click on profile
2. Click on edit icon on the user badge
3. Update username in the modal
4. Submit
The site redirects to `/undefined` endpoint 
