### PR TITLE
fix: redirect Monkeys logo in navbar and footer to '/'

### DIFF
--- a/apps/the_monkeys/src/components/layout/footer/index.tsx
+++ b/apps/the_monkeys/src/components/layout/footer/index.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import Icon, { IconName } from '@/components/icon';
 import Logo from '@/components/logo';
 import { footerLinksList, footerSocialsList } from '@/constants/footer';
-import { FEED_ROUTE } from '@/constants/routeConstants';
+import { HOME_ROUTE} from '@/constants/routeConstants';
 import { Button } from '@the-monkeys/ui/atoms/button';
 
 import Container from '../Container';
@@ -69,7 +69,7 @@ const Footer = () => {
         <div className='grid grid-cols-3 gap-14 lg:gap-4'>
           <div className='col-span-3 lg:col-span-1 space-y-2'>
             <Link
-              href={FEED_ROUTE}
+              href={HOME_ROUTE}
               className='group w-fit flex items-center gap-[6px]'
             >
               <div className='size-10 flex justify-center items-center filter group-hover:brightness-90'>

--- a/apps/the_monkeys/src/components/layout/navbar/Nav.tsx
+++ b/apps/the_monkeys/src/components/layout/navbar/Nav.tsx
@@ -9,7 +9,7 @@ import LoginButton from '@/components/buttons/loginButton';
 import Logo from '@/components/logo';
 import { SearchInput, SearchInputLink } from '@/components/search/SearchInput';
 import ThemeSwitch from '@/components/themeSwitch';
-import { FEED_ROUTE } from '@/constants/routeConstants';
+import { HOME_ROUTE } from '@/constants/routeConstants';
 import { IUser } from '@/services/models/user';
 import { twMerge } from 'tailwind-merge';
 
@@ -53,7 +53,7 @@ const Nav = ({
     >
       <Container className='w-full max-w-[1500px] px-[10px] py-3 flex items-center justify-between gap-4'>
         <div className='flex items-center gap-[10px] sm:gap-4'>
-          <Link href={FEED_ROUTE} className='group flex items-center gap-[6px]'>
+          <Link href={HOME_ROUTE} className='group flex items-center gap-[6px]'>
             <div className='w-9 flex justify-center items-center filter group-hover:brightness-90'>
               <Logo />
             </div>


### PR DESCRIPTION
### 📃 Why Merge This PR?
changed the route from FEED_ROUTE to HOME_ROUTE for the logo + text in both navbar and footer.

### 🛠️ Issue Fixed

Fixes #443   

### 🔍 PR Type

- [ ✖️] 💡 Feature
- [ ✔️] 🐛 Bug Fix
- [✖️ ] 📃 Documentation
- [ ✖️] 🎨 UI Improvements
- [✖️ ] 💻 Code Refactor
- [ ✖️] ✅ Tests
