### PR TITLE
Snapshot v2 studio with blog/brand templates

### DIFF
--- a/apps/the_monkeys/.gitignore
+++ b/apps/the_monkeys/.gitignore
@@ -38,3 +38,8 @@ next-env.d.ts
 
 certificates
 .turbo
+
+# local dev artefacts
+lint_output.txt
+tsc_output.txt
+tsc_results.log

--- a/apps/the_monkeys/package.json
+++ b/apps/the_monkeys/package.json
@@ -36,6 +36,7 @@
     "d3": "^7.9.0",
     "d3-cloud": "^1.2.7",
     "date-fns": "^3.6.0",
+    "html-to-image": "^1.11.13",
     "isomorphic-dompurify": "^2.13.0",
     "jose": "^5.9.6",
     "moment": "^2.30.1",

--- a/apps/the_monkeys/src/app/snapshot/[blogId]/page.tsx
+++ b/apps/the_monkeys/src/app/snapshot/[blogId]/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import Link from 'next/link';
+
+import {
+  extractBlogImages,
+  fromBlog,
+} from '@/features/snapshot/adapters/fromBlog';
+import { SnapshotStudio } from '@/features/snapshot/components/SnapshotStudio';
+import { useSnapshotAuthor } from '@/features/snapshot/hooks/useSnapshotAuthor';
+import useGetPublishedBlogDetailByBlogId from '@/hooks/blog/useGetPublishedBlogDetailByBlogId';
+import useGetProfileInfoById from '@/hooks/user/useGetProfileInfoByUserId';
+import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
+
+interface SnapshotStudioPageProps {
+  params: { blogId: string };
+}
+
+export default function SnapshotStudioPage({
+  params,
+}: SnapshotStudioPageProps) {
+  const blogId = decodeURIComponent(params.blogId);
+  const { blog, isLoading, isError } =
+    useGetPublishedBlogDetailByBlogId(blogId);
+  const { user: profile } = useGetProfileInfoById(blog?.owner_account_id);
+
+  const authorUsername = profile?.user?.username;
+  const displayName = useMemo(() => {
+    const fn = profile?.user?.first_name?.trim();
+    const ln = profile?.user?.last_name?.trim();
+    return (
+      [fn, ln].filter(Boolean).join(' ') || authorUsername || 'the_monkeys'
+    );
+  }, [profile?.user?.first_name, profile?.user?.last_name, authorUsername]);
+
+  const { author } = useSnapshotAuthor(authorUsername, displayName);
+
+  const input = useMemo(() => {
+    if (!blog) return null;
+    return fromBlog(blog, {
+      author,
+      sourceUrl:
+        typeof window !== 'undefined'
+          ? `${window.location.origin}/blog/${blog.blog_id}`
+          : undefined,
+    });
+  }, [blog, author]);
+
+  const availableImages = useMemo(() => extractBlogImages(blog), [blog]);
+
+  if (isLoading || !blog) {
+    return (
+      <div className='mx-auto w-full max-w-6xl px-4 py-8'>
+        <Skeleton className='mb-4 h-8 w-48' />
+        <Skeleton className='h-[60vh] w-full rounded-2xl' />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className='mx-auto max-w-md px-4 py-16 text-center'>
+        <h1 className='mb-2 font-newsreader text-2xl'>Snapshot unavailable</h1>
+        <p className='mb-6 text-foreground/70'>
+          We could not load this post. It may be unpublished.
+        </p>
+        <Link href='/snapshot' className='text-brand-orange underline'>
+          Pick another post
+        </Link>
+      </div>
+    );
+  }
+
+  if (!input) return null;
+
+  return (
+    <div className='mx-auto w-full max-w-6xl px-4 py-6'>
+      <div className='mb-4 flex items-center justify-between'>
+        <div>
+          <Link
+            href='/snapshot'
+            className='text-xs text-foreground/60 hover:text-foreground'
+          >
+            ← All posts
+          </Link>
+          <h1 className='font-newsreader text-2xl'>
+            Snapshot
+            <span className='text-brand-orange'>.</span>
+          </h1>
+        </div>
+      </div>
+      <SnapshotStudio input={input} availableImages={availableImages} />
+    </div>
+  );
+}

--- a/apps/the_monkeys/src/app/snapshot/new/page.tsx
+++ b/apps/the_monkeys/src/app/snapshot/new/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import Link from 'next/link';
+
+import { SnapshotStudio } from '@/features/snapshot/components/SnapshotStudio';
+import { useSnapshotAuthor } from '@/features/snapshot/hooks/useSnapshotAuthor';
+import { SnapshotInput } from '@/features/snapshot/types';
+import useAuth from '@/hooks/auth/useAuth';
+
+/**
+ * Blank-canvas snapshot studio. Lets any visitor (signed in or out) create a
+ * shareable image without picking a published post first.
+ *
+ * Default content is intentionally generic and editable, so the page is
+ * useful even with no source blog.
+ */
+export default function SnapshotNewPage() {
+  const { data: session } = useAuth();
+  const username = session?.username;
+  const displayName = useMemo(() => {
+    const fn = session?.first_name?.trim();
+    const ln = session?.last_name?.trim();
+    return [fn, ln].filter(Boolean).join(' ') || username || 'the_monkeys';
+  }, [session?.first_name, session?.last_name, username]);
+
+  const { author } = useSnapshotAuthor(username, displayName);
+
+  const input = useMemo<SnapshotInput>(
+    () => ({
+      source: 'manual',
+      title: 'Your headline goes here',
+      description:
+        'A short hook that makes people stop scrolling. Edit it to match your post.',
+      quote: 'Drop a punchy line here for the quote templates.',
+      tags: ['the_monkeys'],
+      author: author ?? {
+        username: username ?? 'the_monkeys',
+        displayName,
+      },
+    }),
+    [author, username, displayName]
+  );
+
+  return (
+    <div className='mx-auto w-full max-w-6xl px-4 py-6'>
+      <div className='mb-4'>
+        <Link
+          href='/snapshot'
+          className='text-xs text-foreground/60 hover:text-foreground'
+        >
+          ← Pick a post instead
+        </Link>
+        <h1 className='font-newsreader text-2xl'>
+          Snapshot
+          <span className='text-brand-orange'>.</span>{' '}
+          <span className='text-foreground/60'>blank canvas</span>
+        </h1>
+        <p className='text-xs text-foreground/60'>
+          Type your own title, description and pull-quote. Choose a template,
+          theme, and accent — then download.
+        </p>
+      </div>
+      <SnapshotStudio input={input} />
+    </div>
+  );
+}

--- a/apps/the_monkeys/src/app/snapshot/page.tsx
+++ b/apps/the_monkeys/src/app/snapshot/page.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import useAuth from '@/hooks/auth/useAuth';
+import useGetPublishedBlogByUsername from '@/hooks/blog/useGetPublishedBlogByUsername';
+import { Button } from '@the-monkeys/ui/atoms/button';
+import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
+
+export default function SnapshotPickerPage() {
+  const router = useRouter();
+  const { data: authUser, isLoading: authLoading } = useAuth();
+  const username = authUser?.username;
+
+  const { blogs, isLoading, isError } = useGetPublishedBlogByUsername({
+    username,
+    limit: 30,
+    offset: 0,
+  });
+
+  if (authLoading || isLoading) {
+    return (
+      <div className='mx-auto w-full max-w-5xl px-4 py-8'>
+        <h1 className='mb-2 font-newsreader text-3xl'>Snapshot</h1>
+        <p className='mb-6 text-foreground/60'>
+          Generate share-ready social images from your published posts.
+        </p>
+        <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className='h-40 w-full rounded-xl' />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!username) {
+    return (
+      <div className='mx-auto w-full max-w-md px-4 py-16 text-center'>
+        <h1 className='mb-2 font-newsreader text-3xl'>Snapshot</h1>
+        <p className='mb-6 text-foreground/70'>
+          Sign in to generate social images from your posts, or start from a
+          blank canvas.
+        </p>
+        <div className='flex flex-col items-center gap-3'>
+          <Button onClick={() => router.push('/auth/login')}>Sign in</Button>
+          <Link
+            href='/snapshot/new'
+            className='text-sm text-brand-orange underline'
+          >
+            Start from scratch
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const list = blogs?.blogs ?? [];
+
+  return (
+    <div className='mx-auto w-full max-w-5xl px-4 py-8'>
+      <header className='mb-6'>
+        <h1 className='font-newsreader text-3xl'>
+          Snapshot
+          <span className='text-brand-orange'>.</span>
+        </h1>
+        <p className='text-foreground/60'>
+          Pick a published post to turn into a social-ready image, or start from
+          a blank canvas.
+        </p>
+      </header>
+
+      {isError ? (
+        <p role='alert' className='text-sm text-alert-red'>
+          Could not load your posts. Please try again.
+        </p>
+      ) : null}
+
+      <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+        <Link
+          href='/snapshot/new'
+          className='group flex h-full min-h-[14rem] flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-brand-orange/40 bg-brand-orange/5 p-4 text-center transition-colors hover:border-brand-orange hover:bg-brand-orange/10'
+        >
+          <span className='font-newsreader text-2xl text-brand-orange'>
+            Start from scratch
+          </span>
+          <span className='text-xs text-foreground/60'>
+            Type your own headline, description and quote — no post required.
+          </span>
+        </Link>
+
+        {list.length === 0 ? (
+          <div className='col-span-full rounded-xl border border-dashed p-8 text-center text-foreground/60 sm:col-span-1 lg:col-span-2'>
+            You have no published posts yet.
+          </div>
+        ) : (
+          list.map((meta) => (
+            <Link
+              key={meta.blog_id}
+              href={`/snapshot/${encodeURIComponent(meta.blog_id)}`}
+              className='group flex flex-col gap-2 overflow-hidden rounded-xl border bg-foreground-light/30 p-3 transition-colors hover:border-brand-orange/60 dark:bg-foreground-dark/20'
+            >
+              {meta.first_image ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={meta.first_image}
+                  alt=''
+                  className='h-32 w-full rounded-lg object-cover'
+                  loading='lazy'
+                />
+              ) : (
+                <div className='flex h-32 w-full items-center justify-center rounded-lg bg-foreground-light/50 text-foreground/40 dark:bg-foreground-dark/40'>
+                  No cover
+                </div>
+              )}
+              <h2 className='line-clamp-2 font-newsreader text-base capitalize'>
+                {meta.title || 'Untitled'}
+              </h2>
+              <p className='line-clamp-2 text-xs text-foreground/60'>
+                {meta.first_paragraph}
+              </p>
+            </Link>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/the_monkeys/src/components/social/SocialSnapshot.tsx
+++ b/apps/the_monkeys/src/components/social/SocialSnapshot.tsx
@@ -1,8 +1,8 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 import { Blog } from '@/services/blog/blogTypes';
-
-import { SocialSnapshotDialog } from './SocialSnapshotDialog';
+import { Button } from '@the-monkeys/ui/atoms/button';
 
 export const SocialSnapshotCard = ({ blog }: { blog: Blog }) => {
   return (
@@ -23,7 +23,11 @@ export const SocialSnapshotCard = ({ blog }: { blog: Blog }) => {
         </div>
 
         <div className='py-2'>
-          <SocialSnapshotDialog blog={blog} />
+          <Button asChild variant='brand'>
+            <Link href={`/snapshot/${encodeURIComponent(blog.blog_id)}`}>
+              Open Studio →
+            </Link>
+          </Button>
         </div>
       </div>
 

--- a/apps/the_monkeys/src/constants/routeConstants.ts
+++ b/apps/the_monkeys/src/constants/routeConstants.ts
@@ -11,6 +11,7 @@ export const DRAFT_ROUTE = '/library?source=drafts';
 export const SCHEDULE_ROUTE = '/library?source=scheudle';
 export const BOOKMARK_ROUTE = '/library?source=bookmarks';
 export const BLOG_ROUTE = '/blog';
+export const SNAPSHOT_ROUTE = '/snapshot';
 export const EXPLORE_TOPICS_ROUTE = '/topics/explore';
 export const TOPIC_ROUTE = '/topics';
 export const TOPIC_SITEMAP_ROUTE = '/topics/sitemap.xml';
@@ -27,8 +28,14 @@ export type NavItem = {
 
 export const DISCOVER_ITEMS: NavItem[] = [
   { href: HOME_ROUTE, label: 'Feed', icon: 'RiNewspaper' },
-  { href: FEED_ROUTE, label: 'For You', icon: 'RiBard', requiresAuth: true },
   { href: EXPLORE_TOPICS_ROUTE, label: 'Topics', icon: 'RiCompass' },
+  { href: FEED_ROUTE, label: 'For You', icon: 'RiBard', requiresAuth: true },
+  {
+    href: SNAPSHOT_ROUTE,
+    label: 'Snapshot',
+    icon: 'RiCameraLens',
+    requiresAuth: true,
+  },
   {
     href: BOOKMARK_ROUTE,
     label: 'Library',

--- a/apps/the_monkeys/src/features/snapshot/adapters/fromBlog.ts
+++ b/apps/the_monkeys/src/features/snapshot/adapters/fromBlog.ts
@@ -1,0 +1,81 @@
+import { getCardContent } from '@/components/blog/getBlogContent';
+import { Blog } from '@/services/blog/blogTypes';
+
+import { SnapshotAuthor, SnapshotInput } from '../types';
+
+/**
+ * Strip residual HTML tags. `getCardContent` returns sanitized HTML strings
+ * (DOMPurify) but they may still contain markup like `<b>` or `<a>`.
+ * For our Satori-safe templates we need plain text only.
+ */
+const stripTags = (html: string | null | undefined): string => {
+  if (!html) return '';
+  return html
+    .replace(/<br\s*\/?>(\s*)/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+/** Rough reading time estimate at 220 wpm. */
+const estimateReadingTime = (blog: Blog): number => {
+  const wordCount = (blog.blog?.blocks ?? []).reduce((acc, block) => {
+    const txt =
+      (block.data?.text as string | undefined) ??
+      (Array.isArray(block.data?.items) ? block.data.items.join(' ') : '');
+    if (!txt) return acc;
+    return acc + txt.split(/\s+/).filter(Boolean).length;
+  }, 0);
+  return Math.max(1, Math.round(wordCount / 220));
+};
+
+/**
+ * Returns every image URL referenced by the blog, in document order, with
+ * duplicates removed. Used to populate the snapshot background picker.
+ */
+export const extractBlogImages = (blog: Blog | undefined | null): string[] => {
+  if (!blog?.blog?.blocks) return [];
+  const urls: string[] = [];
+  for (const block of blog.blog.blocks) {
+    if (block.type !== 'image') continue;
+    const url: unknown = block?.data?.file?.url ?? block?.data?.url;
+    if (typeof url === 'string' && url.trim().length > 0) {
+      urls.push(url);
+    }
+  }
+  return Array.from(new Set(urls));
+};
+
+export interface FromBlogOpts {
+  author?: SnapshotAuthor;
+  /** Public canonical URL of the blog. */
+  sourceUrl?: string;
+}
+
+export const fromBlog = (
+  blog: Blog,
+  opts: FromBlogOpts = {}
+): SnapshotInput => {
+  const { titleContent, descriptionContent, imageContent } = getCardContent({
+    blog,
+  });
+
+  return {
+    source: 'blog',
+    sourceId: blog.blog_id,
+    sourceUrl: opts.sourceUrl,
+    title: stripTags(titleContent) || 'Untitled',
+    description: stripTags(descriptionContent) || undefined,
+    heroImageUrl: imageContent ?? undefined,
+    tags: Array.isArray(blog.tags) ? blog.tags.slice(0, 6) : undefined,
+    author: opts.author,
+    publishedAt: blog.published_time,
+    readingTimeMin: estimateReadingTime(blog),
+  };
+};

--- a/apps/the_monkeys/src/features/snapshot/adapters/fromMetaBlog.ts
+++ b/apps/the_monkeys/src/features/snapshot/adapters/fromMetaBlog.ts
@@ -1,0 +1,33 @@
+import { MetaBlog } from '@/services/blog/blogTypes';
+
+import { SnapshotAuthor, SnapshotInput } from '../types';
+
+const stripTags = (html: string | null | undefined): string => {
+  if (!html) return '';
+  return html
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+export interface FromMetaBlogOpts {
+  author?: SnapshotAuthor;
+  sourceUrl?: string;
+}
+
+export const fromMetaBlog = (
+  meta: MetaBlog,
+  opts: FromMetaBlogOpts = {}
+): SnapshotInput => ({
+  source: 'meta-blog',
+  sourceId: meta.blog_id,
+  sourceUrl: opts.sourceUrl,
+  title: stripTags(meta.title) || 'Untitled',
+  description: stripTags(meta.first_paragraph) || undefined,
+  heroImageUrl: meta.first_image || undefined,
+  tags: Array.isArray(meta.tags) ? meta.tags.slice(0, 6) : undefined,
+  author: opts.author,
+  publishedAt: meta.published_time,
+});

--- a/apps/the_monkeys/src/features/snapshot/adapters/fromTweet.ts
+++ b/apps/the_monkeys/src/features/snapshot/adapters/fromTweet.ts
@@ -1,0 +1,11 @@
+import { SnapshotInput } from '../types';
+
+/**
+ * Stub: tweet ingestion requires X API credentials and is owned by the Cast
+ * service. Frontend just enqueues the request once available.
+ */
+export const fromTweet = async (_tweetUrl: string): Promise<SnapshotInput> => {
+  throw new Error(
+    'snapshot.fromTweet is not implemented in the frontend; route via /api/v2/cast/ingest/tweet.'
+  );
+};

--- a/apps/the_monkeys/src/features/snapshot/adapters/fromUrl.ts
+++ b/apps/the_monkeys/src/features/snapshot/adapters/fromUrl.ts
@@ -1,0 +1,12 @@
+import { SnapshotInput } from '../types';
+
+/**
+ * Stub: extracting a SnapshotInput from an arbitrary URL is handled by the
+ * `the_monkeys_cast` ingest worker (server-side via OpenGraph + Readability).
+ * Surface kept here so the frontend API is stable.
+ */
+export const fromUrl = async (_url: string): Promise<SnapshotInput> => {
+  throw new Error(
+    'snapshot.fromUrl is not implemented in the frontend; route via /api/v2/cast/ingest/url.'
+  );
+};

--- a/apps/the_monkeys/src/features/snapshot/components/AccentColorPicker.tsx
+++ b/apps/the_monkeys/src/features/snapshot/components/AccentColorPicker.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { ACCENT_PALETTE } from '../themes';
+
+export interface AccentColorPickerProps {
+  value: string;
+  onChange: (color: string) => void;
+}
+
+export const AccentColorPicker = ({
+  value,
+  onChange,
+}: AccentColorPickerProps) => {
+  return (
+    <div className='flex flex-wrap gap-2'>
+      {ACCENT_PALETTE.map((color) => {
+        const selected = color.toLowerCase() === value.toLowerCase();
+        return (
+          <button
+            key={color}
+            type='button'
+            onClick={() => onChange(color)}
+            aria-label={`Accent ${color}`}
+            aria-pressed={selected}
+            className='h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-brand-orange/40'
+            style={{
+              backgroundColor: color,
+              borderColor: selected ? '#000' : 'transparent',
+              boxShadow: selected ? '0 0 0 2px white inset' : 'none',
+            }}
+          />
+        );
+      })}
+      <label className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border border-dashed border-foreground/30 text-xs'>
+        <input
+          type='color'
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className='h-0 w-0 opacity-0'
+          aria-label='Custom accent color'
+        />
+        +
+      </label>
+    </div>
+  );
+};

--- a/apps/the_monkeys/src/features/snapshot/components/BackgroundPicker.tsx
+++ b/apps/the_monkeys/src/features/snapshot/components/BackgroundPicker.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+export interface BackgroundPickerProps {
+  value: string | undefined;
+  images: string[];
+  overlay: number;
+  onChangeImage: (url: string | undefined) => void;
+  onChangeOverlay: (overlay: number) => void;
+}
+
+export const BackgroundPicker = ({
+  value,
+  images,
+  overlay,
+  onChangeImage,
+  onChangeOverlay,
+}: BackgroundPickerProps) => {
+  const hasImage = !!value;
+  return (
+    <div className='flex flex-col gap-3'>
+      <div className='flex flex-wrap gap-2'>
+        <button
+          type='button'
+          onClick={() => onChangeImage(undefined)}
+          aria-pressed={!hasImage}
+          className='flex h-16 w-16 items-center justify-center rounded-md border-2 text-[10px] uppercase tracking-wide text-foreground/60 transition-colors hover:border-brand-orange/60 focus:outline-none focus:ring-2 focus:ring-brand-orange/40'
+          style={{
+            borderColor: !hasImage ? '#FF5542' : 'rgba(127,127,127,0.3)',
+          }}
+        >
+          None
+        </button>
+        {images.map((src) => {
+          const selected = value === src;
+          return (
+            <button
+              key={src}
+              type='button'
+              onClick={() => onChangeImage(src)}
+              aria-pressed={selected}
+              className='h-16 w-16 overflow-hidden rounded-md border-2 transition-colors hover:border-brand-orange/60 focus:outline-none focus:ring-2 focus:ring-brand-orange/40'
+              style={{
+                borderColor: selected ? '#FF5542' : 'rgba(127,127,127,0.3)',
+              }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={src}
+                alt=''
+                className='h-full w-full object-cover'
+                loading='lazy'
+              />
+            </button>
+          );
+        })}
+        {images.length === 0 ? (
+          <span className='self-center text-xs text-foreground/50'>
+            No images found in this post.
+          </span>
+        ) : null}
+      </div>
+
+      {hasImage ? (
+        <label className='flex items-center gap-3 text-xs text-foreground/70'>
+          <span className='w-16 shrink-0'>Darken</span>
+          <input
+            type='range'
+            min={0}
+            max={1}
+            step={0.05}
+            value={overlay}
+            onChange={(e) => onChangeOverlay(Number(e.target.value))}
+            className='flex-1 accent-brand-orange'
+            aria-label='Background overlay strength'
+          />
+          <span className='w-10 text-right font-mono'>
+            {Math.round(overlay * 100)}%
+          </span>
+        </label>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/the_monkeys/src/features/snapshot/components/DownloadButton.tsx
+++ b/apps/the_monkeys/src/features/snapshot/components/DownloadButton.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Button } from '@the-monkeys/ui/atoms/button';
+
+import { SnapshotExportOptions } from '../types';
+
+export interface DownloadButtonProps {
+  isExporting: boolean;
+  onExport: (opts?: SnapshotExportOptions) => Promise<unknown>;
+  filename: string;
+  disabled?: boolean;
+}
+
+export const DownloadButton = ({
+  isExporting,
+  onExport,
+  filename,
+  disabled,
+}: DownloadButtonProps) => {
+  return (
+    <div className='flex flex-col gap-2 sm:flex-row sm:flex-wrap'>
+      <Button
+        className='w-full sm:w-auto'
+        onClick={() => onExport({ format: 'png', pixelRatio: 2, filename })}
+        disabled={isExporting || disabled}
+      >
+        {isExporting ? 'Rendering…' : 'Download PNG'}
+      </Button>
+      <Button
+        className='w-full sm:w-auto'
+        variant='outline'
+        onClick={() => onExport({ format: 'jpeg', pixelRatio: 2, filename })}
+        disabled={isExporting || disabled}
+      >
+        Download JPEG
+      </Button>
+    </div>
+  );
+};

--- a/apps/the_monkeys/src/features/snapshot/components/OptionsPanel.tsx
+++ b/apps/the_monkeys/src/features/snapshot/components/OptionsPanel.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Input } from '@the-monkeys/ui/atoms/input';
+import { Label } from '@the-monkeys/ui/atoms/label';
+import { TextArea } from '@the-monkeys/ui/atoms/text-area';
+
+import { SnapshotInput } from '../types';
+
+export interface OptionsPanelProps {
+  input: SnapshotInput;
+  onChange: (patch: Partial<SnapshotInput>) => void;
+}
+
+export const OptionsPanel = ({ input, onChange }: OptionsPanelProps) => {
+  return (
+    <div className='flex flex-col gap-3'>
+      <div className='flex flex-col gap-1'>
+        <Label htmlFor='snap-title' className='text-xs'>
+          Title
+        </Label>
+        <Input
+          id='snap-title'
+          value={input.title}
+          maxLength={240}
+          onChange={(e) => onChange({ title: e.target.value })}
+        />
+      </div>
+
+      <div className='flex flex-col gap-1'>
+        <Label htmlFor='snap-description' className='text-xs'>
+          Description
+        </Label>
+        <TextArea
+          id='snap-description'
+          value={input.description ?? ''}
+          maxLength={600}
+          rows={3}
+          onChange={(e) => onChange({ description: e.target.value })}
+        />
+      </div>
+
+      <div className='flex flex-col gap-1'>
+        <Label htmlFor='snap-quote' className='text-xs'>
+          Pull-quote (used by quote templates)
+        </Label>
+        <TextArea
+          id='snap-quote'
+          value={input.quote ?? ''}
+          maxLength={280}
+          rows={2}
+          onChange={(e) => onChange({ quote: e.target.value })}
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/the_monkeys/src/features/snapshot/components/SnapshotPreview.tsx
+++ b/apps/the_monkeys/src/features/snapshot/components/SnapshotPreview.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { CSSProperties, forwardRef, useEffect, useRef, useState } from 'react';
+
+import { getTemplateById } from '../registry';
+import { getThemeById } from '../themes';
+import { SnapshotInput } from '../types';
+
+export interface SnapshotPreviewProps {
+  input: SnapshotInput;
+  templateId: string;
+  themeId: string;
+  accent: string;
+  /** Max width of the preview container in CSS pixels. */
+  maxPreviewWidth?: number;
+  /** Background "stage" colour around the canvas. */
+  stageBackground?: string;
+  className?: string;
+}
+
+/**
+ * Renders the selected template at its native px size inside a fixed-size
+ * wrapper, then scales the wrapper with CSS `transform` so the visible preview
+ * fits the available area without affecting the export pipeline (which still
+ * reads the native dimensions via a ref).
+ */
+export const SnapshotPreview = forwardRef<HTMLDivElement, SnapshotPreviewProps>(
+  function SnapshotPreview(
+    {
+      input,
+      templateId,
+      themeId,
+      accent,
+      maxPreviewWidth,
+      stageBackground = 'transparent',
+      className,
+    },
+    ref
+  ) {
+    const template = getTemplateById(templateId);
+    const theme = getThemeById(themeId);
+    const stageRef = useRef<HTMLDivElement | null>(null);
+    const [scale, setScale] = useState(1);
+
+    useEffect(() => {
+      if (!stageRef.current) return;
+      const el = stageRef.current;
+      const update = () => {
+        const available = maxPreviewWidth ?? el.clientWidth;
+        if (!available) return;
+        const next = Math.min(1, available / template.width);
+        setScale(next);
+      };
+      update();
+      const ro = new ResizeObserver(update);
+      ro.observe(el);
+      return () => ro.disconnect();
+    }, [template.width, maxPreviewWidth]);
+
+    const Render = template.Render;
+    const scaledWidth = template.width * scale;
+    const scaledHeight = template.height * scale;
+
+    const stageStyle: CSSProperties = {
+      width: '100%',
+      maxWidth: maxPreviewWidth,
+      backgroundColor: stageBackground,
+    };
+
+    return (
+      <div ref={stageRef} className={className} style={stageStyle}>
+        <div
+          style={{
+            width: scaledWidth,
+            height: scaledHeight,
+            overflow: 'hidden',
+            marginLeft: 'auto',
+            marginRight: 'auto',
+          }}
+        >
+          {/*
+           * The CSS scale lives on this wrapper, NOT on the ref'd
+           * element below. If we put `transform` on the export root,
+           * html-to-image would serialize the transform into its
+           * SVG output and produce a tiny image in the top-left of
+           * a native-sized canvas.
+           */}
+          <div
+            style={{
+              width: template.width,
+              height: template.height,
+              transform: `scale(${scale})`,
+              transformOrigin: 'top left',
+            }}
+          >
+            <div
+              ref={ref}
+              style={{
+                width: template.width,
+                height: template.height,
+              }}
+            >
+              <Render input={input} theme={theme} accent={accent} />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+);

--- a/apps/the_monkeys/src/features/snapshot/components/SnapshotStudio.tsx
+++ b/apps/the_monkeys/src/features/snapshot/components/SnapshotStudio.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useMemo, useRef } from 'react';
+
+import { useDataUrlImage } from '../hooks/useDataUrlImage';
+import { useExport } from '../hooks/useExport';
+import { useSnapshotState } from '../hooks/useSnapshotState';
+import { getTemplateById } from '../registry';
+import { SnapshotInput } from '../types';
+import { AccentColorPicker } from './AccentColorPicker';
+import { BackgroundPicker } from './BackgroundPicker';
+import { DownloadButton } from './DownloadButton';
+import { OptionsPanel } from './OptionsPanel';
+import { SnapshotPreview } from './SnapshotPreview';
+import { TemplatePicker } from './TemplatePicker';
+import { ThemePicker } from './ThemePicker';
+
+export interface SnapshotStudioProps {
+  input: SnapshotInput;
+  /**
+   * Pool of candidate background images (e.g. every image embedded in the
+   * source blog). Falsy or empty means "no background picker".
+   */
+  availableImages?: string[];
+  /** Optional initial template, defaults to editorial-portrait. */
+  initialTemplateId?: string;
+  initialThemeId?: string;
+  initialAccent?: string;
+}
+
+/**
+ * Top-level orchestrator. Composer-ready: when the Cast composer is built it
+ * will mount this same component inside its media panel with no rewrites.
+ */
+export const SnapshotStudio = ({
+  input,
+  availableImages = [],
+  initialTemplateId,
+  initialThemeId,
+  initialAccent,
+}: SnapshotStudioProps) => {
+  const { state, updateInput, setTemplate, setTheme, setAccent } =
+    useSnapshotState({
+      initialInput: input,
+      initialTemplateId,
+      initialThemeId,
+      initialAccent,
+    });
+
+  // Resolve the chosen background to a data URL so html-to-image can embed it
+  // without cross-origin canvas tainting.
+  const bgDataUrl = useDataUrlImage(state.input.backgroundImageUrl);
+  const renderedInput = useMemo<SnapshotInput>(
+    () => ({
+      ...state.input,
+      backgroundImageUrl: bgDataUrl,
+    }),
+    [state.input, bgDataUrl]
+  );
+
+  const template = getTemplateById(state.templateId);
+  const snapshotRef = useRef<HTMLDivElement | null>(null);
+  const { exportImage, isExporting, error } = useExport(snapshotRef, {
+    width: template.width,
+    height: template.height,
+    slice: template.slice,
+  });
+
+  const filename = `${state.input.title || 'snapshot'}-${template.id}`;
+
+  return (
+    <div className='grid w-full grid-cols-1 gap-6 lg:grid-cols-[1fr_minmax(320px,420px)]'>
+      <section className='flex min-w-0 flex-col gap-3'>
+        <div className='flex items-center justify-between gap-2'>
+          <div>
+            <h2 className='font-newsreader text-2xl'>{template.label}</h2>
+            <p className='text-xs text-foreground/60'>
+              {template.width}×{template.height} · {template.aspect}
+            </p>
+          </div>
+        </div>
+
+        <div className='rounded-2xl border bg-foreground-light/30 p-2 dark:bg-foreground-dark/20 sm:p-4'>
+          <SnapshotPreview
+            ref={snapshotRef}
+            input={renderedInput}
+            templateId={state.templateId}
+            themeId={state.themeId}
+            accent={state.accent}
+          />
+        </div>
+
+        {error ? (
+          <p role='alert' className='text-sm text-alert-red'>
+            Export failed: {error.message}
+          </p>
+        ) : null}
+      </section>
+
+      <aside className='flex flex-col gap-5'>
+        <div className='flex flex-col gap-2'>
+          <h3 className='text-sm font-semibold uppercase tracking-wide text-foreground/60'>
+            Template
+          </h3>
+          <TemplatePicker value={state.templateId} onChange={setTemplate} />
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          <h3 className='text-sm font-semibold uppercase tracking-wide text-foreground/60'>
+            Theme
+          </h3>
+          <ThemePicker value={state.themeId} onChange={setTheme} />
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          <h3 className='text-sm font-semibold uppercase tracking-wide text-foreground/60'>
+            Accent
+          </h3>
+          <AccentColorPicker value={state.accent} onChange={setAccent} />
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          <h3 className='text-sm font-semibold uppercase tracking-wide text-foreground/60'>
+            Background
+          </h3>
+          <BackgroundPicker
+            value={state.input.backgroundImageUrl}
+            images={availableImages}
+            overlay={state.input.backgroundOverlay ?? 0.55}
+            onChangeImage={(url) => updateInput({ backgroundImageUrl: url })}
+            onChangeOverlay={(overlay) =>
+              updateInput({ backgroundOverlay: overlay })
+            }
+          />
+        </div>
+
+        <div className='flex flex-col gap-2'>
+          <h3 className='text-sm font-semibold uppercase tracking-wide text-foreground/60'>
+            Content
+          </h3>
+          <OptionsPanel input={state.input} onChange={updateInput} />
+        </div>
+
+        <div className='sticky bottom-0 -mx-1 mt-2 flex flex-col gap-2 border-t bg-background-light/95 px-1 py-3 dark:bg-background-dark/95'>
+          <DownloadButton
+            isExporting={isExporting}
+            onExport={exportImage}
+            filename={filename}
+          />
+        </div>
+      </aside>
+    </div>
+  );
+};

--- a/apps/the_monkeys/src/features/snapshot/components/TemplatePicker.tsx
+++ b/apps/the_monkeys/src/features/snapshot/components/TemplatePicker.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { SNAPSHOT_TEMPLATES } from '../registry';
+
+export interface TemplatePickerProps {
+  value: string;
+  onChange: (templateId: string) => void;
+}
+
+export const TemplatePicker = ({ value, onChange }: TemplatePickerProps) => {
+  return (
+    <div className='grid grid-cols-2 gap-2 sm:grid-cols-3'>
+      {SNAPSHOT_TEMPLATES.map((tpl) => {
+        const selected = tpl.id === value;
+        return (
+          <button
+            key={tpl.id}
+            type='button'
+            onClick={() => onChange(tpl.id)}
+            className='group flex flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors focus:outline-none focus:ring-2 focus:ring-brand-orange/40'
+            style={{
+              borderColor: selected ? '#FF5542' : 'rgba(127,127,127,0.3)',
+              backgroundColor: selected ? '#FF55420F' : 'transparent',
+            }}
+          >
+            <div className='flex w-full items-center justify-between'>
+              <span className='text-sm font-semibold'>{tpl.label}</span>
+              <span className='font-mono text-[10px] text-foreground/50'>
+                {tpl.aspect}
+              </span>
+            </div>
+            <span className='text-xs text-foreground/60'>
+              {tpl.description}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/the_monkeys/src/features/snapshot/components/ThemePicker.tsx
+++ b/apps/the_monkeys/src/features/snapshot/components/ThemePicker.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { SNAPSHOT_THEMES } from '../themes';
+
+export interface ThemePickerProps {
+  value: string;
+  onChange: (themeId: string) => void;
+}
+
+export const ThemePicker = ({ value, onChange }: ThemePickerProps) => {
+  return (
+    <div className='flex flex-wrap gap-2'>
+      {SNAPSHOT_THEMES.map((theme) => {
+        const selected = theme.id === value;
+        return (
+          <button
+            key={theme.id}
+            type='button'
+            onClick={() => onChange(theme.id)}
+            className='flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-brand-orange/40'
+            style={{
+              borderColor: selected ? theme.accent : 'rgba(127,127,127,0.3)',
+              backgroundColor: selected ? `${theme.accent}10` : 'transparent',
+            }}
+          >
+            <span
+              className='h-4 w-4 rounded-full border'
+              style={{
+                backgroundColor: theme.background,
+                backgroundImage: theme.backgroundImage,
+                borderColor: theme.border,
+              }}
+            />
+            <span className='font-medium'>{theme.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/the_monkeys/src/features/snapshot/hooks/useDataUrlImage.ts
+++ b/apps/the_monkeys/src/features/snapshot/hooks/useDataUrlImage.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Fetches a possibly-cross-origin image URL through Next's image proxy and
+ * converts it to a data URL so it can be embedded in `html-to-image` exports
+ * without tainting the canvas.
+ *
+ * Returns the original URL unchanged for empty/undefined or already-data URLs.
+ */
+export const useDataUrlImage = (
+  url: string | undefined
+): string | undefined => {
+  const [dataUrl, setDataUrl] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!url) {
+      setDataUrl(undefined);
+      return;
+    }
+    if (url.startsWith('data:')) {
+      setDataUrl(url);
+      return;
+    }
+
+    let cancelled = false;
+    const isAbsolute = /^https?:\/\//i.test(url);
+    const fetchUrl = isAbsolute
+      ? `/api/proxy-image?url=${encodeURIComponent(url)}`
+      : url;
+
+    fetch(fetchUrl)
+      .then((r) => {
+        if (!r.ok) throw new Error(`proxy ${r.status}`);
+        return r.blob();
+      })
+      .then(
+        (blob) =>
+          new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onloadend = () => resolve(String(reader.result));
+            reader.onerror = () => reject(reader.error);
+            reader.readAsDataURL(blob);
+          })
+      )
+      .then((next) => {
+        if (cancelled) return;
+        setDataUrl(next);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setDataUrl(undefined);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+
+  return dataUrl;
+};

--- a/apps/the_monkeys/src/features/snapshot/hooks/useExport.ts
+++ b/apps/the_monkeys/src/features/snapshot/hooks/useExport.ts
@@ -1,0 +1,190 @@
+'use client';
+
+import { RefObject, useCallback, useState } from 'react';
+
+import { SnapshotExportOptions } from '../types';
+
+const slugify = (s: string) =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'snapshot';
+
+const triggerDownload = (blob: Blob, filename: string) => {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  // Defer revoke so Safari has time to honor the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+};
+
+const loadImage = (src: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to decode export blob'));
+    img.src = src;
+  });
+
+const canvasToBlob = (
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number
+): Promise<Blob> =>
+  new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (b) =>
+        b ? resolve(b) : reject(new Error('canvas.toBlob returned null')),
+      type,
+      quality
+    );
+  });
+
+/**
+ * Slices a single rendered blob horizontally into `count` equal-width sub
+ * images. Used to turn the carousel's 3240×1350 strip into three 1080×1350
+ * downloads without re-rendering the DOM.
+ */
+const sliceBlobHorizontally = async (
+  blob: Blob,
+  totalWidth: number,
+  totalHeight: number,
+  count: number,
+  sliceWidth: number,
+  sliceHeight: number,
+  mimeType: string,
+  quality: number
+): Promise<Blob[]> => {
+  const objectUrl = URL.createObjectURL(blob);
+  try {
+    const img = await loadImage(objectUrl);
+    // html-to-image already applied pixelRatio, so img.width >= totalWidth.
+    const scaleX = img.width / totalWidth;
+    const scaleY = img.height / totalHeight;
+    const out: Blob[] = [];
+    for (let i = 0; i < count; i++) {
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.round(sliceWidth * scaleX);
+      canvas.height = Math.round(sliceHeight * scaleY);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) throw new Error('2D canvas unavailable');
+      ctx.drawImage(
+        img,
+        Math.round(i * sliceWidth * scaleX),
+        0,
+        canvas.width,
+        canvas.height,
+        0,
+        0,
+        canvas.width,
+        canvas.height
+      );
+      // eslint-disable-next-line no-await-in-loop
+      out.push(await canvasToBlob(canvas, mimeType, quality));
+    }
+    return out;
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+};
+
+export interface UseExportOpts {
+  /** Native pixel width of the template root. */
+  width: number;
+  /** Native pixel height of the template root. */
+  height: number;
+  /**
+   * Multi-slide export config. When set, the rendered blob is cut into
+   * `count` equal-width pieces and each is downloaded as its own file.
+   */
+  slice?: {
+    count: number;
+    sliceWidth: number;
+    sliceHeight: number;
+  };
+}
+
+/**
+ * Wraps `html-to-image` `toBlob`. We dynamic-import the lib so it never lands
+ * in the initial bundle for users who never open the studio.
+ */
+export const useExport = (
+  nodeRef: RefObject<HTMLDivElement | null>,
+  { width, height, slice }: UseExportOpts
+) => {
+  const [isExporting, setIsExporting] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const exportImage = useCallback(
+    async (opts: SnapshotExportOptions = {}) => {
+      const node = nodeRef.current;
+      if (!node) {
+        setError(new Error('Snapshot node not mounted'));
+        return null;
+      }
+      const { pixelRatio = 2, format = 'png', quality = 0.95, filename } = opts;
+
+      setIsExporting(true);
+      setError(null);
+      try {
+        const { toBlob } = await import('html-to-image');
+        const mimeType = format === 'jpeg' ? 'image/jpeg' : 'image/png';
+        const blob = await toBlob(node, {
+          cacheBust: true,
+          width,
+          height,
+          pixelRatio,
+          backgroundColor: undefined,
+          type: mimeType,
+          quality,
+          // Skip nodes that are explicitly excluded (e.g. dev overlays).
+          filter: (el) =>
+            !(
+              el instanceof HTMLElement && el.dataset.snapshotIgnore === 'true'
+            ),
+        });
+        if (!blob) throw new Error('html-to-image returned no blob');
+        const ext = format === 'jpeg' ? 'jpg' : 'png';
+        const baseName = slugify(filename ?? 'snapshot');
+
+        if (slice && slice.count > 1) {
+          const parts = await sliceBlobHorizontally(
+            blob,
+            width,
+            height,
+            slice.count,
+            slice.sliceWidth,
+            slice.sliceHeight,
+            mimeType,
+            quality
+          );
+          // Chrome throttles bursts of downloads; stagger them slightly.
+          parts.forEach((part, i) => {
+            setTimeout(
+              () => triggerDownload(part, `${baseName}-${i + 1}.${ext}`),
+              i * 250
+            );
+          });
+          return blob;
+        }
+
+        triggerDownload(blob, `${baseName}.${ext}`);
+        return blob;
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err));
+        setError(e);
+        return null;
+      } finally {
+        setIsExporting(false);
+      }
+    },
+    [nodeRef, width, height, slice]
+  );
+
+  return { exportImage, isExporting, error };
+};

--- a/apps/the_monkeys/src/features/snapshot/hooks/useSnapshotAuthor.ts
+++ b/apps/the_monkeys/src/features/snapshot/hooks/useSnapshotAuthor.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import useProfileImage from '@/hooks/profile/useProfileImage';
+
+import { SnapshotAuthor } from '../types';
+
+/**
+ * Resolves the avatar URL into a data URL so it survives `html-to-image`'s
+ * canvas tainting check. Profiles are served via authenticated fetch as Blob.
+ */
+export const useSnapshotAuthor = (
+  username: string | undefined,
+  displayName: string
+): { author: SnapshotAuthor | undefined; isReady: boolean } => {
+  const { imageUrl } = useProfileImage(username);
+  const [dataUrl, setDataUrl] = useState<string | undefined>(undefined);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsReady(false);
+
+    if (!imageUrl) {
+      setDataUrl(undefined);
+      setIsReady(true);
+      return;
+    }
+
+    fetch(imageUrl)
+      .then((r) => r.blob())
+      .then(
+        (blob) =>
+          new Promise<string>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onloadend = () => resolve(String(reader.result));
+            reader.onerror = () => reject(reader.error);
+            reader.readAsDataURL(blob);
+          })
+      )
+      .then((url) => {
+        if (cancelled) return;
+        setDataUrl(url);
+        setIsReady(true);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setDataUrl(undefined);
+        setIsReady(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [imageUrl]);
+
+  if (!username) return { author: undefined, isReady: true };
+
+  return {
+    author: {
+      username,
+      displayName,
+      avatarUrl: dataUrl,
+    },
+    isReady,
+  };
+};

--- a/apps/the_monkeys/src/features/snapshot/hooks/useSnapshotState.ts
+++ b/apps/the_monkeys/src/features/snapshot/hooks/useSnapshotState.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+
+import { DEFAULT_TEMPLATE_ID } from '../registry';
+import { ACCENT_PALETTE, DEFAULT_THEME_ID } from '../themes';
+import { SnapshotInput, SnapshotState } from '../types';
+
+export interface UseSnapshotStateOpts {
+  initialInput: SnapshotInput;
+  initialTemplateId?: string;
+  initialThemeId?: string;
+  initialAccent?: string;
+}
+
+export const useSnapshotState = ({
+  initialInput,
+  initialTemplateId = DEFAULT_TEMPLATE_ID,
+  initialThemeId = DEFAULT_THEME_ID,
+  initialAccent = ACCENT_PALETTE[0],
+}: UseSnapshotStateOpts) => {
+  const [state, setState] = useState<SnapshotState>({
+    input: initialInput,
+    templateId: initialTemplateId,
+    themeId: initialThemeId,
+    accent: initialAccent,
+  });
+
+  const updateInput = useCallback((patch: Partial<SnapshotInput>) => {
+    setState((s) => ({ ...s, input: { ...s.input, ...patch } }));
+  }, []);
+
+  const setTemplate = useCallback((templateId: string) => {
+    setState((s) => ({ ...s, templateId }));
+  }, []);
+
+  const setTheme = useCallback((themeId: string) => {
+    setState((s) => ({ ...s, themeId }));
+  }, []);
+
+  const setAccent = useCallback((accent: string) => {
+    setState((s) => ({ ...s, accent }));
+  }, []);
+
+  const resetInput = useCallback((next: SnapshotInput) => {
+    setState((s) => ({ ...s, input: next }));
+  }, []);
+
+  return useMemo(
+    () => ({
+      state,
+      updateInput,
+      setTemplate,
+      setTheme,
+      setAccent,
+      resetInput,
+    }),
+    [state, updateInput, setTemplate, setTheme, setAccent, resetInput]
+  );
+};

--- a/apps/the_monkeys/src/features/snapshot/index.ts
+++ b/apps/the_monkeys/src/features/snapshot/index.ts
@@ -1,0 +1,12 @@
+export * from './types';
+export * from './schemas';
+export * from './registry';
+export * from './themes';
+export { fromBlog } from './adapters/fromBlog';
+export { fromMetaBlog } from './adapters/fromMetaBlog';
+export { fromUrl } from './adapters/fromUrl';
+export { fromTweet } from './adapters/fromTweet';
+export { useSnapshotState } from './hooks/useSnapshotState';
+export { useExport } from './hooks/useExport';
+export { SnapshotStudio } from './components/SnapshotStudio';
+export { SnapshotPreview } from './components/SnapshotPreview';

--- a/apps/the_monkeys/src/features/snapshot/registry.ts
+++ b/apps/the_monkeys/src/features/snapshot/registry.ts
@@ -1,0 +1,23 @@
+import { editorialPortrait } from './templates/EditorialPortrait';
+import { instagramCarousel } from './templates/InstagramCarousel';
+import { linkedinShare } from './templates/LinkedInShare';
+import { quoteCard } from './templates/QuoteCard';
+import { storyVertical } from './templates/StoryVertical';
+import { threadCover } from './templates/ThreadCover';
+import { xShare } from './templates/XShare';
+import { SnapshotTemplate } from './types';
+
+export const SNAPSHOT_TEMPLATES: SnapshotTemplate[] = [
+  editorialPortrait,
+  quoteCard,
+  threadCover,
+  instagramCarousel,
+  xShare,
+  linkedinShare,
+  storyVertical,
+];
+
+export const DEFAULT_TEMPLATE_ID = editorialPortrait.id;
+
+export const getTemplateById = (id: string): SnapshotTemplate =>
+  SNAPSHOT_TEMPLATES.find((t) => t.id === id) ?? SNAPSHOT_TEMPLATES[0];

--- a/apps/the_monkeys/src/features/snapshot/schemas.ts
+++ b/apps/the_monkeys/src/features/snapshot/schemas.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const snapshotAuthorSchema = z.object({
+  username: z.string().min(1),
+  displayName: z.string().min(1),
+  avatarUrl: z.string().url().optional(),
+});
+
+export const snapshotInputSchema = z.object({
+  source: z.enum(['blog', 'meta-blog', 'url', 'tweet', 'manual']),
+  sourceId: z.string().optional(),
+  sourceUrl: z.string().url().optional(),
+  title: z.string().min(1).max(240),
+  description: z.string().max(600).optional(),
+  quote: z.string().max(280).optional(),
+  heroImageUrl: z.string().url().optional(),
+  tags: z.array(z.string().min(1).max(40)).max(10).optional(),
+  author: snapshotAuthorSchema.optional(),
+  publishedAt: z.string().optional(),
+  readingTimeMin: z.number().int().nonnegative().optional(),
+});
+
+export type SnapshotInputParsed = z.infer<typeof snapshotInputSchema>;

--- a/apps/the_monkeys/src/features/snapshot/templates/EditorialPortrait.tsx
+++ b/apps/the_monkeys/src/features/snapshot/templates/EditorialPortrait.tsx
@@ -1,0 +1,155 @@
+import { SnapshotRenderProps, SnapshotTemplate } from '../types';
+import {
+  AccentBar,
+  Avatar,
+  Col,
+  FONT_STACK,
+  Logo,
+  Row,
+  SHELL_BASE,
+  Tag,
+  clip,
+  getShellBackground,
+} from './_shared';
+
+const WIDTH = 1080;
+const HEIGHT = 1350;
+
+const Render = ({ input, theme, accent }: SnapshotRenderProps): JSX.Element => {
+  return (
+    <div
+      style={{
+        ...SHELL_BASE,
+        width: WIDTH,
+        height: HEIGHT,
+        ...getShellBackground(theme, input),
+        color: theme.foreground,
+        padding: 72,
+        justifyContent: 'space-between',
+        fontFamily: FONT_STACK,
+      }}
+    >
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <Logo color={theme.foreground} accent={accent} size={30} />
+        <div
+          style={{
+            display: 'flex',
+            color: theme.muted,
+            fontSize: 22,
+            letterSpacing: 0.4,
+            textTransform: 'uppercase',
+          }}
+        >
+          Snapshot
+        </div>
+      </Row>
+
+      <Col style={{ gap: 28 }}>
+        <AccentBar color={accent} width={84} height={8} />
+
+        <div
+          style={{
+            display: 'flex',
+            fontSize:
+              input.title.length > 80 ? 64 : input.title.length > 40 ? 76 : 92,
+            lineHeight: 1.05,
+            fontWeight: 700,
+            letterSpacing: -1.5,
+            color: theme.foreground,
+          }}
+        >
+          {clip(input.title, 160)}
+        </div>
+
+        {input.description ? (
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 30,
+              lineHeight: 1.4,
+              color: theme.muted,
+              fontWeight: 400,
+              letterSpacing: -0.3,
+            }}
+          >
+            {clip(input.description, 220)}
+          </div>
+        ) : null}
+
+        {input.tags && input.tags.length ? (
+          <Row style={{ gap: 12, flexWrap: 'wrap' }}>
+            {input.tags.slice(0, 4).map((t) => (
+              <Tag
+                key={t}
+                label={`#${t}`}
+                color={theme.foreground}
+                bg={theme.surface}
+              />
+            ))}
+          </Row>
+        ) : null}
+      </Col>
+
+      <Row
+        style={{
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingTop: 28,
+          borderTop: `2px solid ${theme.border}`,
+        }}
+      >
+        <Row style={{ alignItems: 'center', gap: 18 }}>
+          <Avatar
+            src={input.author?.avatarUrl}
+            fallback={input.author?.displayName ?? 'TM'}
+            accent={accent}
+            size={72}
+          />
+          <Col>
+            <div
+              style={{
+                display: 'flex',
+                fontSize: 28,
+                fontWeight: 600,
+                color: theme.foreground,
+              }}
+            >
+              {input.author?.displayName ?? 'the_monkeys'}
+            </div>
+            {input.author?.username ? (
+              <div
+                style={{ display: 'flex', fontSize: 22, color: theme.muted }}
+              >
+                @{input.author.username}
+              </div>
+            ) : null}
+          </Col>
+        </Row>
+
+        {typeof input.readingTimeMin === 'number' ? (
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 22,
+              color: theme.muted,
+              fontWeight: 500,
+            }}
+          >
+            {input.readingTimeMin} min read
+          </div>
+        ) : null}
+      </Row>
+    </div>
+  );
+};
+
+export const editorialPortrait: SnapshotTemplate = {
+  id: 'editorial-portrait',
+  label: 'Editorial Portrait',
+  description: 'Magazine-style 4:5 with bold headline and author footer.',
+  aspect: '1080x1350',
+  width: WIDTH,
+  height: HEIGHT,
+  channels: ['instagram'],
+  Render,
+};

--- a/apps/the_monkeys/src/features/snapshot/templates/InstagramCarousel.tsx
+++ b/apps/the_monkeys/src/features/snapshot/templates/InstagramCarousel.tsx
@@ -1,0 +1,372 @@
+import { CSSProperties } from 'react';
+
+import { SnapshotRenderProps, SnapshotTemplate } from '../types';
+import {
+  AccentBar,
+  Avatar,
+  BRAND_URL,
+  Col,
+  FONT_STACK,
+  Logo,
+  Row,
+  SHELL_BASE,
+  Tag,
+  clip,
+  getShellBackground,
+} from './_shared';
+
+const SLIDE_W = 1080;
+const SLIDE_H = 1350;
+const SLIDE_COUNT = 3;
+const WIDTH = SLIDE_W * SLIDE_COUNT;
+const HEIGHT = SLIDE_H;
+const GUTTER = 0; // exported as 3 separate 1080×1350 files; slides must be flush
+
+/**
+ * Splits the description into ~equal halves on word boundaries.
+ * Used to fill slide 2 with the hook and slide 3 with the continuation.
+ */
+const splitForSlides = (text: string | undefined): [string, string] => {
+  const safe = (text ?? '').trim();
+  if (!safe) return ['', ''];
+  const words = safe.split(/\s+/);
+  if (words.length < 18) return [safe, ''];
+  const mid = Math.ceil(words.length / 2);
+  return [words.slice(0, mid).join(' '), words.slice(mid).join(' ')];
+};
+
+interface SlideShellProps {
+  children: React.ReactNode;
+  background: CSSProperties;
+  foreground: string;
+  marginRight: number;
+}
+
+const SlideShell = ({
+  children,
+  background,
+  foreground,
+  marginRight,
+}: SlideShellProps): JSX.Element => (
+  <div
+    style={{
+      ...SHELL_BASE,
+      width: SLIDE_W,
+      height: SLIDE_H,
+      ...background,
+      color: foreground,
+      padding: 72,
+      justifyContent: 'space-between',
+      fontFamily: FONT_STACK,
+      marginRight,
+    }}
+  >
+    {children}
+  </div>
+);
+
+const Render = ({ input, theme, accent }: SnapshotRenderProps): JSX.Element => {
+  const background = getShellBackground(theme, input);
+  const [descA, descB] = splitForSlides(input.description);
+  const quote = input.quote ?? descA;
+
+  const titleSize =
+    input.title.length > 80 ? 64 : input.title.length > 40 ? 76 : 92;
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        width: WIDTH,
+        height: HEIGHT,
+        backgroundColor: theme.border,
+        fontFamily: FONT_STACK,
+      }}
+    >
+      {/* SLIDE 1 — Cover */}
+      <SlideShell
+        background={background}
+        foreground={theme.foreground}
+        marginRight={GUTTER}
+      >
+        <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+          <Logo color={theme.foreground} accent={accent} size={30} />
+          <div
+            style={{
+              display: 'flex',
+              color: theme.muted,
+              fontSize: 20,
+              letterSpacing: 0.4,
+              textTransform: 'uppercase',
+            }}
+          >
+            1 / {SLIDE_COUNT}
+          </div>
+        </Row>
+
+        <Col style={{ gap: 28 }}>
+          <AccentBar color={accent} width={84} height={8} />
+          <div
+            style={{
+              display: 'flex',
+              fontSize: titleSize,
+              lineHeight: 1.05,
+              fontWeight: 700,
+              letterSpacing: -1.5,
+              color: theme.foreground,
+            }}
+          >
+            {clip(input.title, 160)}
+          </div>
+          {input.tags && input.tags.length ? (
+            <Row style={{ gap: 12, flexWrap: 'wrap' }}>
+              {input.tags.slice(0, 4).map((t) => (
+                <Tag
+                  key={t}
+                  label={`#${t}`}
+                  color={theme.foreground}
+                  bg={theme.surface}
+                />
+              ))}
+            </Row>
+          ) : null}
+        </Col>
+
+        <Row
+          style={{
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            paddingTop: 28,
+            borderTop: `2px solid ${theme.border}`,
+          }}
+        >
+          <Row style={{ alignItems: 'center', gap: 18 }}>
+            <Avatar
+              src={input.author?.avatarUrl}
+              fallback={input.author?.displayName ?? 'TM'}
+              accent={accent}
+              size={64}
+            />
+            <Col>
+              <div
+                style={{
+                  display: 'flex',
+                  fontSize: 26,
+                  fontWeight: 600,
+                  color: theme.foreground,
+                }}
+              >
+                {input.author?.displayName ?? 'the_monkeys'}
+              </div>
+              {input.author?.username ? (
+                <div
+                  style={{
+                    display: 'flex',
+                    fontSize: 20,
+                    color: theme.muted,
+                  }}
+                >
+                  @{input.author.username}
+                </div>
+              ) : null}
+            </Col>
+          </Row>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 22,
+              color: theme.muted,
+              fontWeight: 500,
+            }}
+          >
+            Swipe →
+          </div>
+        </Row>
+      </SlideShell>
+
+      {/* SLIDE 2 — Pull-quote / hook */}
+      <SlideShell
+        background={background}
+        foreground={theme.foreground}
+        marginRight={GUTTER}
+      >
+        <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+          <Logo color={theme.foreground} accent={accent} size={30} />
+          <div
+            style={{
+              display: 'flex',
+              color: theme.muted,
+              fontSize: 20,
+              letterSpacing: 0.4,
+              textTransform: 'uppercase',
+            }}
+          >
+            2 / {SLIDE_COUNT}
+          </div>
+        </Row>
+
+        <Col style={{ gap: 28, justifyContent: 'center', flex: 1 }}>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 160,
+              lineHeight: 0.8,
+              fontWeight: 700,
+              color: accent,
+              letterSpacing: -4,
+            }}
+          >
+            “
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: quote.length > 220 ? 40 : quote.length > 120 ? 52 : 64,
+              lineHeight: 1.25,
+              fontWeight: 500,
+              color: theme.foreground,
+              letterSpacing: -0.8,
+            }}
+          >
+            {clip(quote || input.title, 320)}
+          </div>
+        </Col>
+
+        <Row
+          style={{
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            paddingTop: 28,
+            borderTop: `2px solid ${theme.border}`,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 22,
+              color: theme.muted,
+              fontWeight: 500,
+            }}
+          >
+            Swipe →
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 22,
+              color: theme.muted,
+            }}
+          >
+            {BRAND_URL}
+          </div>
+        </Row>
+      </SlideShell>
+
+      {/* SLIDE 3 — Continuation + CTA */}
+      <SlideShell
+        background={background}
+        foreground={theme.foreground}
+        marginRight={0}
+      >
+        <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+          <Logo color={theme.foreground} accent={accent} size={30} />
+          <div
+            style={{
+              display: 'flex',
+              color: theme.muted,
+              fontSize: 20,
+              letterSpacing: 0.4,
+              textTransform: 'uppercase',
+            }}
+          >
+            3 / {SLIDE_COUNT}
+          </div>
+        </Row>
+
+        <Col style={{ gap: 24, justifyContent: 'center', flex: 1 }}>
+          <AccentBar color={accent} width={84} height={8} />
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 36,
+              lineHeight: 1.35,
+              color: theme.foreground,
+              fontWeight: 500,
+            }}
+          >
+            {clip(descB || descA || input.title, 360)}
+          </div>
+        </Col>
+
+        <Col style={{ gap: 18 }}>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 32,
+              fontWeight: 700,
+              color: accent,
+              letterSpacing: -0.4,
+            }}
+          >
+            Read the full story →
+          </div>
+          <Row
+            style={{
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              paddingTop: 24,
+              borderTop: `2px solid ${theme.border}`,
+            }}
+          >
+            <Row style={{ alignItems: 'center', gap: 14 }}>
+              <Avatar
+                src={input.author?.avatarUrl}
+                fallback={input.author?.displayName ?? 'TM'}
+                accent={accent}
+                size={56}
+              />
+              <div
+                style={{
+                  display: 'flex',
+                  fontSize: 24,
+                  color: theme.foreground,
+                  fontWeight: 600,
+                }}
+              >
+                {input.author?.displayName ?? 'the_monkeys'}
+              </div>
+            </Row>
+            <div
+              style={{
+                display: 'flex',
+                fontSize: 24,
+                color: theme.muted,
+                fontWeight: 600,
+              }}
+            >
+              {BRAND_URL}
+            </div>
+          </Row>
+        </Col>
+      </SlideShell>
+    </div>
+  );
+};
+
+export const instagramCarousel: SnapshotTemplate = {
+  id: 'instagram-carousel',
+  label: 'Instagram Carousel',
+  description:
+    "3 separate 1080×1350 slides (cover, pull-quote, CTA) — downloaded as three files ready for Instagram's carousel uploader.",
+  aspect: '3240x1350',
+  width: WIDTH,
+  height: HEIGHT,
+  channels: ['instagram'],
+  slice: {
+    count: SLIDE_COUNT,
+    sliceWidth: SLIDE_W,
+    sliceHeight: SLIDE_H,
+  },
+  Render,
+};

--- a/apps/the_monkeys/src/features/snapshot/templates/LinkedInShare.tsx
+++ b/apps/the_monkeys/src/features/snapshot/templates/LinkedInShare.tsx
@@ -1,0 +1,119 @@
+import { SnapshotRenderProps, SnapshotTemplate } from '../types';
+import {
+  AccentBar,
+  Avatar,
+  Col,
+  FONT_STACK,
+  Logo,
+  Row,
+  SHELL_BASE,
+  clip,
+  getShellBackground,
+} from './_shared';
+
+const WIDTH = 1200;
+const HEIGHT = 627;
+
+const Render = ({ input, theme, accent }: SnapshotRenderProps): JSX.Element => {
+  return (
+    <div
+      style={{
+        ...SHELL_BASE,
+        width: WIDTH,
+        height: HEIGHT,
+        ...getShellBackground(theme, input),
+        color: theme.foreground,
+        padding: 56,
+        justifyContent: 'space-between',
+        fontFamily: FONT_STACK,
+      }}
+    >
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <Logo color={theme.foreground} accent={accent} size={24} />
+        <Row style={{ gap: 8, alignItems: 'center' }}>
+          <AccentBar color={accent} width={28} height={4} />
+          <div
+            style={{
+              display: 'flex',
+              color: theme.muted,
+              fontSize: 20,
+              letterSpacing: 0.6,
+              textTransform: 'uppercase',
+            }}
+          >
+            Long Read
+          </div>
+        </Row>
+      </Row>
+
+      <Col style={{ gap: 20 }}>
+        <div
+          style={{
+            display: 'flex',
+            fontSize: input.title.length > 90 ? 44 : 54,
+            lineHeight: 1.1,
+            fontWeight: 700,
+            letterSpacing: -0.8,
+            color: theme.foreground,
+          }}
+        >
+          {clip(input.title, 150)}
+        </div>
+        {input.description ? (
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 22,
+              lineHeight: 1.45,
+              color: theme.muted,
+            }}
+          >
+            {clip(input.description, 180)}
+          </div>
+        ) : null}
+      </Col>
+
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <Row style={{ alignItems: 'center', gap: 14 }}>
+          <Avatar
+            src={input.author?.avatarUrl}
+            fallback={input.author?.displayName ?? 'TM'}
+            accent={accent}
+            size={48}
+          />
+          <Col>
+            <div
+              style={{
+                display: 'flex',
+                fontSize: 20,
+                fontWeight: 600,
+                color: theme.foreground,
+              }}
+            >
+              {input.author?.displayName ?? 'the_monkeys'}
+            </div>
+            <div style={{ display: 'flex', fontSize: 18, color: theme.muted }}>
+              Published on the_monkeys
+            </div>
+          </Col>
+        </Row>
+        {typeof input.readingTimeMin === 'number' ? (
+          <div style={{ display: 'flex', color: theme.muted, fontSize: 18 }}>
+            {input.readingTimeMin} min read
+          </div>
+        ) : null}
+      </Row>
+    </div>
+  );
+};
+
+export const linkedinShare: SnapshotTemplate = {
+  id: 'linkedin-share',
+  label: 'LinkedIn',
+  description: '1.91:1 share card tuned for LinkedIn feed.',
+  aspect: '1200x627',
+  width: WIDTH,
+  height: HEIGHT,
+  channels: ['linkedin'],
+  Render,
+};

--- a/apps/the_monkeys/src/features/snapshot/templates/QuoteCard.tsx
+++ b/apps/the_monkeys/src/features/snapshot/templates/QuoteCard.tsx
@@ -1,0 +1,85 @@
+import { SnapshotRenderProps, SnapshotTemplate } from '../types';
+import {
+  AccentBar,
+  Col,
+  FONT_STACK,
+  Logo,
+  Row,
+  SHELL_BASE,
+  clip,
+  getShellBackground,
+} from './_shared';
+
+const WIDTH = 1080;
+const HEIGHT = 1080;
+
+const Render = ({ input, theme, accent }: SnapshotRenderProps): JSX.Element => {
+  const text = input.quote || input.description || input.title;
+  return (
+    <div
+      style={{
+        ...SHELL_BASE,
+        width: WIDTH,
+        height: HEIGHT,
+        ...getShellBackground(theme, input),
+        color: theme.foreground,
+        padding: 80,
+        justifyContent: 'space-between',
+        fontFamily: FONT_STACK,
+      }}
+    >
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <Logo color={theme.foreground} accent={accent} size={28} />
+        <div style={{ display: 'flex', color: theme.muted, fontSize: 22 }}>
+          {input.author?.username ? `@${input.author.username}` : ''}
+        </div>
+      </Row>
+
+      <Col style={{ gap: 36 }}>
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 220,
+            lineHeight: 0.8,
+            color: accent,
+            fontWeight: 700,
+            fontFamily: 'Georgia, serif',
+            height: 120,
+          }}
+        >
+          “
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            fontSize: text.length > 160 ? 48 : text.length > 80 ? 58 : 68,
+            lineHeight: 1.2,
+            fontWeight: 600,
+            letterSpacing: -0.8,
+            color: theme.foreground,
+          }}
+        >
+          {clip(text, 260)}
+        </div>
+      </Col>
+
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <AccentBar color={accent} width={72} height={6} />
+        <div style={{ display: 'flex', color: theme.muted, fontSize: 22 }}>
+          {input.author?.displayName ?? 'the_monkeys'}
+        </div>
+      </Row>
+    </div>
+  );
+};
+
+export const quoteCard: SnapshotTemplate = {
+  id: 'quote-card',
+  label: 'Quote Card',
+  description: 'Pull-quote in a 1:1 frame, ideal for IG feed.',
+  aspect: '1080x1080',
+  width: WIDTH,
+  height: HEIGHT,
+  channels: ['instagram'],
+  Render,
+};

--- a/apps/the_monkeys/src/features/snapshot/templates/StoryVertical.tsx
+++ b/apps/the_monkeys/src/features/snapshot/templates/StoryVertical.tsx
@@ -1,0 +1,106 @@
+import { SnapshotRenderProps, SnapshotTemplate } from '../types';
+import {
+  AccentBar,
+  BRAND_URL,
+  Col,
+  FONT_STACK,
+  Logo,
+  Row,
+  SHELL_BASE,
+  clip,
+  getShellBackground,
+} from './_shared';
+
+const WIDTH = 1080;
+const HEIGHT = 1920;
+
+const Render = ({ input, theme, accent }: SnapshotRenderProps): JSX.Element => {
+  return (
+    <div
+      style={{
+        ...SHELL_BASE,
+        width: WIDTH,
+        height: HEIGHT,
+        ...getShellBackground(theme, input),
+        color: theme.foreground,
+        padding: 96,
+        justifyContent: 'space-between',
+        fontFamily: FONT_STACK,
+      }}
+    >
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <Logo color={theme.foreground} accent={accent} size={32} />
+        <div
+          style={{
+            display: 'flex',
+            color: theme.muted,
+            fontSize: 26,
+            letterSpacing: 0.6,
+            textTransform: 'uppercase',
+          }}
+        >
+          Story
+        </div>
+      </Row>
+
+      <Col style={{ gap: 40 }}>
+        <AccentBar color={accent} width={120} height={10} />
+        <div
+          style={{
+            display: 'flex',
+            fontSize: input.title.length > 60 ? 96 : 120,
+            lineHeight: 1.05,
+            fontWeight: 700,
+            letterSpacing: -2,
+            color: theme.foreground,
+          }}
+        >
+          {clip(input.title, 120)}
+        </div>
+        {input.description ? (
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 36,
+              lineHeight: 1.4,
+              color: theme.muted,
+            }}
+          >
+            {clip(input.description, 180)}
+          </div>
+        ) : null}
+      </Col>
+
+      <Col style={{ gap: 18 }}>
+        <div
+          style={{
+            display: 'flex',
+            color: accent,
+            fontSize: 30,
+            fontWeight: 700,
+            letterSpacing: 0.6,
+            textTransform: 'uppercase',
+          }}
+        >
+          Swipe Up to Read
+        </div>
+        <div style={{ display: 'flex', color: theme.muted, fontSize: 26 }}>
+          {input.author?.username
+            ? `@${input.author.username} · ${BRAND_URL}`
+            : BRAND_URL}
+        </div>
+      </Col>
+    </div>
+  );
+};
+
+export const storyVertical: SnapshotTemplate = {
+  id: 'story-vertical',
+  label: 'Story / Reel',
+  description: '9:16 vertical, ideal for Stories and Reels covers.',
+  aspect: '1080x1920',
+  width: WIDTH,
+  height: HEIGHT,
+  channels: ['story'],
+  Render,
+};

--- a/apps/the_monkeys/src/features/snapshot/templates/ThreadCover.tsx
+++ b/apps/the_monkeys/src/features/snapshot/templates/ThreadCover.tsx
@@ -1,0 +1,107 @@
+import { SnapshotRenderProps, SnapshotTemplate } from '../types';
+import {
+  AccentBar,
+  Col,
+  FONT_STACK,
+  Logo,
+  Row,
+  SHELL_BASE,
+  clip,
+  getShellBackground,
+} from './_shared';
+
+const WIDTH = 1080;
+const HEIGHT = 1080;
+
+const Render = ({ input, theme, accent }: SnapshotRenderProps): JSX.Element => {
+  return (
+    <div
+      style={{
+        ...SHELL_BASE,
+        width: WIDTH,
+        height: HEIGHT,
+        ...getShellBackground(theme, input),
+        color: theme.foreground,
+        padding: 80,
+        justifyContent: 'space-between',
+        fontFamily: FONT_STACK,
+      }}
+    >
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <Logo color={theme.foreground} accent={accent} size={28} />
+        <div
+          style={{
+            display: 'flex',
+            paddingLeft: 16,
+            paddingRight: 16,
+            paddingTop: 8,
+            paddingBottom: 8,
+            backgroundColor: accent,
+            color: '#FFFFFF',
+            fontSize: 22,
+            fontWeight: 700,
+            borderRadius: 8,
+            letterSpacing: 0.4,
+          }}
+        >
+          THREAD ↓
+        </div>
+      </Row>
+
+      <Col style={{ gap: 28 }}>
+        <AccentBar color={accent} width={84} height={8} />
+        <div
+          style={{
+            display: 'flex',
+            fontSize: input.title.length > 60 ? 70 : 86,
+            lineHeight: 1.05,
+            fontWeight: 700,
+            letterSpacing: -1.4,
+            color: theme.foreground,
+          }}
+        >
+          {clip(input.title, 140)}
+        </div>
+        {input.description ? (
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 28,
+              lineHeight: 1.4,
+              color: theme.muted,
+            }}
+          >
+            {clip(input.description, 180)}
+          </div>
+        ) : null}
+      </Col>
+
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', color: theme.muted, fontSize: 22 }}>
+          {input.author?.username ? `@${input.author.username}` : 'the_monkeys'}
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            color: theme.muted,
+            fontSize: 22,
+            fontWeight: 600,
+          }}
+        >
+          Swipe →
+        </div>
+      </Row>
+    </div>
+  );
+};
+
+export const threadCover: SnapshotTemplate = {
+  id: 'thread-cover',
+  label: 'Thread Cover',
+  description: '1:1 cover that signals a thread or carousel.',
+  aspect: '1080x1080',
+  width: WIDTH,
+  height: HEIGHT,
+  channels: ['thread', 'instagram'],
+  Render,
+};

--- a/apps/the_monkeys/src/features/snapshot/templates/XShare.tsx
+++ b/apps/the_monkeys/src/features/snapshot/templates/XShare.tsx
@@ -1,0 +1,121 @@
+import { SnapshotRenderProps, SnapshotTemplate } from '../types';
+import {
+  Avatar,
+  BRAND_URL,
+  Col,
+  FONT_STACK,
+  Logo,
+  Row,
+  SHELL_BASE,
+  clip,
+  getShellBackground,
+} from './_shared';
+
+const WIDTH = 1200;
+const HEIGHT = 675;
+
+const Render = ({ input, theme, accent }: SnapshotRenderProps): JSX.Element => {
+  return (
+    <div
+      style={{
+        ...SHELL_BASE,
+        width: WIDTH,
+        height: HEIGHT,
+        ...getShellBackground(theme, input),
+        color: theme.foreground,
+        padding: 56,
+        justifyContent: 'space-between',
+        fontFamily: FONT_STACK,
+      }}
+    >
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <Logo color={theme.foreground} accent={accent} size={24} />
+        {input.tags && input.tags[0] ? (
+          <div
+            style={{
+              display: 'flex',
+              color: accent,
+              fontWeight: 600,
+              fontSize: 22,
+              letterSpacing: 0.4,
+              textTransform: 'uppercase',
+            }}
+          >
+            #{input.tags[0]}
+          </div>
+        ) : null}
+      </Row>
+
+      <Col style={{ gap: 16 }}>
+        <div
+          style={{
+            display: 'flex',
+            fontSize: input.title.length > 80 ? 48 : 58,
+            lineHeight: 1.1,
+            fontWeight: 700,
+            letterSpacing: -1,
+            color: theme.foreground,
+          }}
+        >
+          {clip(input.title, 140)}
+        </div>
+        {input.description ? (
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 22,
+              lineHeight: 1.4,
+              color: theme.muted,
+            }}
+          >
+            {clip(input.description, 160)}
+          </div>
+        ) : null}
+      </Col>
+
+      <Row style={{ alignItems: 'center', justifyContent: 'space-between' }}>
+        <Row style={{ alignItems: 'center', gap: 14 }}>
+          <Avatar
+            src={input.author?.avatarUrl}
+            fallback={input.author?.displayName ?? 'TM'}
+            accent={accent}
+            size={48}
+          />
+          <Col>
+            <div
+              style={{
+                display: 'flex',
+                fontSize: 20,
+                fontWeight: 600,
+                color: theme.foreground,
+              }}
+            >
+              {input.author?.displayName ?? 'the_monkeys'}
+            </div>
+            {input.author?.username ? (
+              <div
+                style={{ display: 'flex', fontSize: 18, color: theme.muted }}
+              >
+                @{input.author.username}
+              </div>
+            ) : null}
+          </Col>
+        </Row>
+        <div style={{ display: 'flex', color: theme.muted, fontSize: 18 }}>
+          themonkeys.live
+        </div>
+      </Row>
+    </div>
+  );
+};
+
+export const xShare: SnapshotTemplate = {
+  id: 'x-share',
+  label: 'X / Twitter',
+  description: '16:9 share card optimised for X timelines.',
+  aspect: '1200x675',
+  width: WIDTH,
+  height: HEIGHT,
+  channels: ['x'],
+  Render,
+};

--- a/apps/the_monkeys/src/features/snapshot/templates/_shared.tsx
+++ b/apps/the_monkeys/src/features/snapshot/templates/_shared.tsx
@@ -1,0 +1,210 @@
+/**
+ * Satori-safe primitives. ONLY use inline styles, flex layouts, and <div>/<span>/<img>.
+ * If you add a new primitive, audit it against https://github.com/vercel/satori#documentation.
+ */
+import { CSSProperties } from 'react';
+
+import { SnapshotInput, SnapshotTheme } from '../types';
+
+export const FONT_STACK =
+  '"DM Sans","Inter","Helvetica Neue",Helvetica,Arial,sans-serif';
+
+/**
+ * Resolves the root background for a template, honouring (in order):
+ *   1. `input.backgroundImageUrl` — full-bleed image with darken overlay.
+ *   2. `theme.backgroundImage` — gradient or other CSS background.
+ *   3. `theme.background` — solid colour fallback.
+ *
+ * Returned style is meant to be spread onto the template's root `<div>`.
+ */
+export const getShellBackground = (
+  theme: SnapshotTheme,
+  input: SnapshotInput
+): CSSProperties => {
+  if (input.backgroundImageUrl) {
+    const overlay = Math.max(0, Math.min(1, input.backgroundOverlay ?? 0.55));
+    const tint =
+      theme.mode === 'light'
+        ? `rgba(255,255,255,${overlay})`
+        : `rgba(0,0,0,${overlay})`;
+    return {
+      backgroundColor: theme.background,
+      backgroundImage: `linear-gradient(${tint}, ${tint}), url("${input.backgroundImageUrl}")`,
+      backgroundSize: 'cover',
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+    };
+  }
+  if (theme.backgroundImage) {
+    return {
+      backgroundColor: theme.background,
+      backgroundImage: theme.backgroundImage,
+    };
+  }
+  return { backgroundColor: theme.background };
+};
+
+export const SHELL_BASE: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  fontFamily: FONT_STACK,
+  position: 'relative',
+  overflow: 'hidden',
+};
+
+export const Row: React.FC<{
+  children: React.ReactNode;
+  style?: CSSProperties;
+}> = ({ children, style }) => (
+  <div style={{ display: 'flex', flexDirection: 'row', ...style }}>
+    {children}
+  </div>
+);
+
+export const Col: React.FC<{
+  children: React.ReactNode;
+  style?: CSSProperties;
+}> = ({ children, style }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', ...style }}>
+    {children}
+  </div>
+);
+
+export const AccentBar: React.FC<{
+  color: string;
+  width?: number;
+  height?: number;
+}> = ({ color, width = 64, height = 6 }) => (
+  <div
+    style={{
+      display: 'flex',
+      width,
+      height,
+      backgroundColor: color,
+      borderRadius: 999,
+    }}
+  />
+);
+
+export const Tag: React.FC<{ label: string; color: string; bg: string }> = ({
+  label,
+  color,
+  bg,
+}) => (
+  <div
+    style={{
+      display: 'flex',
+      paddingLeft: 14,
+      paddingRight: 14,
+      paddingTop: 6,
+      paddingBottom: 6,
+      borderRadius: 999,
+      backgroundColor: bg,
+      color,
+      fontSize: 22,
+      fontWeight: 500,
+      letterSpacing: -0.2,
+    }}
+  >
+    {label}
+  </div>
+);
+
+export const Avatar: React.FC<{
+  src?: string;
+  fallback: string;
+  size?: number;
+  accent: string;
+}> = ({ src, fallback, size = 64, accent }) => {
+  if (src) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={src}
+        alt=''
+        width={size}
+        height={size}
+        style={{
+          width: size,
+          height: size,
+          borderRadius: size,
+          objectFit: 'cover',
+          display: 'flex',
+        }}
+      />
+    );
+  }
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: size,
+        height: size,
+        borderRadius: size,
+        backgroundColor: accent,
+        color: '#FFFFFF',
+        fontWeight: 700,
+        fontSize: size * 0.42,
+      }}
+    >
+      {fallback.slice(0, 2).toUpperCase()}
+    </div>
+  );
+};
+
+/**
+ * Public logo asset. Resolved by the browser via Next's /public folder for
+ * `html-to-image`. For Satori (server-side render) callers must pre-inline
+ * this as a data URI — track via `LOGO_ASSET_PATH`.
+ */
+export const LOGO_ASSET_PATH = '/logo-brand.svg';
+export const BRAND_URL = 'monkeys.com.co';
+
+export const Logo: React.FC<{
+  color: string;
+  accent: string;
+  size?: number;
+}> = ({ color, accent, size = 26 }) => {
+  const iconSize = Math.round(size * 1.6);
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+      }}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={LOGO_ASSET_PATH}
+        alt=''
+        width={iconSize}
+        height={iconSize}
+        style={{ width: iconSize, height: iconSize, display: 'flex' }}
+      />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          color,
+          fontWeight: 700,
+          fontSize: size,
+          letterSpacing: -0.5,
+        }}
+      >
+        <span style={{ display: 'flex' }}>{BRAND_URL}</span>
+        <span style={{ display: 'flex', color: accent }}>.</span>
+      </div>
+    </div>
+  );
+};
+
+/** Truncate-by-words helper (Satori has no `text-overflow`). */
+export const clip = (text: string | undefined, max: number): string => {
+  if (!text) return '';
+  const t = text.trim();
+  if (t.length <= max) return t;
+  return t.slice(0, max - 1).trimEnd() + '…';
+};

--- a/apps/the_monkeys/src/features/snapshot/themes.ts
+++ b/apps/the_monkeys/src/features/snapshot/themes.ts
@@ -1,0 +1,105 @@
+import { SnapshotTheme } from './types';
+
+export const SNAPSHOT_THEMES: SnapshotTheme[] = [
+  {
+    id: 'light',
+    label: 'Light',
+    mode: 'light',
+    background: '#FFFFFF',
+    surface: '#F7F7F5',
+    foreground: '#0A0A0A',
+    muted: '#525252',
+    border: '#E5E5E5',
+    accent: '#FF5542',
+  },
+  {
+    id: 'dark',
+    label: 'Dark',
+    mode: 'dark',
+    background: '#0A0A0A',
+    surface: '#161616',
+    foreground: '#F5F5F5',
+    muted: '#A3A3A3',
+    border: '#262626',
+    accent: '#FF5542',
+  },
+  {
+    id: 'brand',
+    label: 'Brand',
+    mode: 'dark',
+    background: '#1A0E0B',
+    surface: '#2A1714',
+    foreground: '#FFF4F1',
+    muted: '#E8B8AE',
+    border: '#4A2520',
+    accent: '#FF5542',
+  },
+  {
+    id: 'sunset',
+    label: 'Sunset',
+    mode: 'dark',
+    background: '#2A0E1F',
+    backgroundImage:
+      'linear-gradient(135deg, #FF5542 0%, #B91C5C 45%, #6B21A8 100%)',
+    surface: 'rgba(255,255,255,0.10)',
+    foreground: '#FFF5F0',
+    muted: 'rgba(255,245,240,0.78)',
+    border: 'rgba(255,245,240,0.28)',
+    accent: '#FFE066',
+  },
+  {
+    id: 'ocean',
+    label: 'Ocean',
+    mode: 'dark',
+    background: '#0B1E2D',
+    backgroundImage:
+      'linear-gradient(160deg, #0F2F4F 0%, #0E7490 55%, #14B8A6 100%)',
+    surface: 'rgba(255,255,255,0.10)',
+    foreground: '#F0FAFE',
+    muted: 'rgba(240,250,254,0.78)',
+    border: 'rgba(240,250,254,0.28)',
+    accent: '#FACC15',
+  },
+  {
+    id: 'aurora',
+    label: 'Aurora',
+    mode: 'dark',
+    background: '#0E0B1F',
+    backgroundImage:
+      'linear-gradient(145deg, #1E1B4B 0%, #6D28D9 50%, #DB2777 100%)',
+    surface: 'rgba(255,255,255,0.10)',
+    foreground: '#FAF5FF',
+    muted: 'rgba(250,245,255,0.78)',
+    border: 'rgba(250,245,255,0.28)',
+    accent: '#34D399',
+  },
+  {
+    id: 'paper',
+    label: 'Paper',
+    mode: 'light',
+    background: '#F5F1E8',
+    backgroundImage: 'linear-gradient(180deg, #F8F4EA 0%, #ECE3CC 100%)',
+    surface: '#FFFFFF',
+    foreground: '#1A1410',
+    muted: '#5F574A',
+    border: '#D9CFB8',
+    accent: '#9B2C2C',
+  },
+];
+
+export const DEFAULT_THEME_ID = 'light';
+
+/** Curated accent swatches the user can apply on top of any theme. */
+export const ACCENT_PALETTE: string[] = [
+  '#FF5542', // brand orange
+  '#F59E0B', // amber
+  '#10B981', // emerald
+  '#0EA5E9', // sky
+  '#6366F1', // indigo
+  '#A855F7', // violet
+  '#EC4899', // pink
+  '#0A0A0A', // ink
+];
+
+export const getThemeById = (id: string | undefined): SnapshotTheme =>
+  SNAPSHOT_THEMES.find((t) => t.id === id) ?? SNAPSHOT_THEMES[0];

--- a/apps/the_monkeys/src/features/snapshot/types.ts
+++ b/apps/the_monkeys/src/features/snapshot/types.ts
@@ -1,0 +1,124 @@
+/**
+ * Snapshot v2 — Type contracts
+ *
+ * Design rule: every template is Satori-safe so the SAME component file can be
+ * rendered today by `html-to-image` in the browser AND later by Satori inside
+ * the `the_monkeys_cast` Node sidecar with zero code changes.
+ *
+ * Satori constraints (do not break):
+ *   - Only `<div>`, `<span>`, `<img>` elements.
+ *   - Only inline `style={{...}}`.
+ *   - Flex layouts only (no grid, no float, no position:absolute without left/top).
+ *   - Explicit pixel sizes on the root.
+ *   - Web-safe fonts; pass fonts in at render time when on the server.
+ */
+
+export type SnapshotSource = 'blog' | 'meta-blog' | 'url' | 'tweet' | 'manual';
+
+export interface SnapshotAuthor {
+  username: string;
+  displayName: string;
+  avatarUrl?: string; // remote URL (image proxy handled by export pipeline)
+}
+
+export interface SnapshotInput {
+  source: SnapshotSource;
+  /** Stable id of the originating object (blog_id, tweet_id, url hash, ...). */
+  sourceId?: string;
+  /** Public canonical URL of the original post (optional, shown as footer). */
+  sourceUrl?: string;
+  title: string;
+  description?: string;
+  /** Short pull-quote, used by quote-style templates. */
+  quote?: string;
+  /** Hero image URL, used by templates that show media inline. */
+  heroImageUrl?: string;
+  /**
+   * Full-bleed background image (overrides theme background when set).
+   * Should be a same-origin URL or a data: URL so canvas export does not taint.
+   */
+  backgroundImageUrl?: string;
+  /** 0..1 darken overlay applied above the background image (default 0.55). */
+  backgroundOverlay?: number;
+  tags?: string[];
+  author?: SnapshotAuthor;
+  publishedAt?: string; // ISO
+  readingTimeMin?: number;
+}
+
+export type SnapshotThemeMode = 'light' | 'dark';
+
+export interface SnapshotTheme {
+  id: string;
+  label: string;
+  mode: SnapshotThemeMode;
+  background: string;
+  /**
+   * Optional CSS `background-image` value (e.g. a linear-gradient). When set,
+   * templates render this in place of the solid `background` colour. Keep it
+   * Satori-safe: only `linear-gradient` / `radial-gradient` are supported.
+   */
+  backgroundImage?: string;
+  surface: string;
+  foreground: string;
+  muted: string;
+  border: string;
+  accent: string; // overridden by per-snapshot accent
+}
+
+export type SnapshotAspect =
+  | '1080x1350' // Instagram portrait
+  | '1080x1080' // Square
+  | '1200x675' // X / Twitter share
+  | '1200x627' // LinkedIn share
+  | '1080x1920' // Story / Reel
+  | '3240x1350'; // Instagram carousel (3× portrait slides)
+
+export interface SnapshotTemplateMeta {
+  id: string;
+  label: string;
+  description: string;
+  aspect: SnapshotAspect;
+  width: number;
+  height: number;
+  /** Channels this template is tuned for, used for sorting in the picker. */
+  channels: Array<'instagram' | 'x' | 'linkedin' | 'story' | 'thread'>;
+  /**
+   * If set, the rendered output is sliced horizontally into `count` equal
+   * sub-images on export and each is downloaded as a separate file. Used by
+   * multi-slide templates like the Instagram carousel.
+   */
+  slice?: {
+    count: number;
+    sliceWidth: number;
+    sliceHeight: number;
+  };
+}
+
+export interface SnapshotRenderProps {
+  input: SnapshotInput;
+  theme: SnapshotTheme;
+  accent: string;
+}
+
+export interface SnapshotTemplate extends SnapshotTemplateMeta {
+  Render: (props: SnapshotRenderProps) => JSX.Element;
+}
+
+export interface SnapshotExportOptions {
+  /** Multiplier on top of the template's native pixel size. */
+  pixelRatio?: number;
+  /** PNG (default) or JPEG. */
+  format?: 'png' | 'jpeg';
+  /** JPEG quality 0..1, ignored for png. */
+  quality?: number;
+  /** File name without extension. */
+  filename?: string;
+}
+
+export interface SnapshotState {
+  input: SnapshotInput;
+  templateId: string;
+  themeId: string;
+  accent: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       isomorphic-dompurify:
         specifier: ^2.13.0
         version: 2.22.0
@@ -3156,6 +3159,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
+
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
 
@@ -3722,6 +3728,7 @@ packages:
   next@14.2.26:
     resolution: {integrity: sha512-b81XSLihMwCfwiUVRRja3LphLo4uBBMZEzBBWMaISbKTwOmq3wPknIETy/8000tr7Gq4WmbuFYPS7jOYIf+ZJw==}
     engines: {node: '>=18.17.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -4799,6 +4806,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -7426,7 +7434,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -7460,7 +7468,7 @@ snapshots:
       tinyglobby: 0.2.12
       unrs-resolver: 1.3.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7475,7 +7483,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -7948,6 +7956,8 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   html-escaper@2.0.2: {}
+
+  html-to-image@1.11.13: {}
 
   http-cache-semantics@4.1.1: {}
 


### PR DESCRIPTION
- New /snapshot picker, /snapshot/[blogId] studio, /snapshot/new blank canvas.

- Six templates: editorial portrait, quote card, thread cover, X share, LinkedIn share, story vertical.

- Instagram Carousel template: 3 slides exported as separate 1080x1350 PNG/JPEG files.

- Gradient theme presets (sunset, ocean, aurora, paper) plus background-image picker sourced from blog images, with overlay darken slider.

- html-to-image client export with /api/proxy-image data-URL pipeline to avoid canvas taint; responsive studio layout for mobile.

- Sidebar nav entry under Login-to-unlock (RiCameraLens).

### 📃 Why Merge This PR?

Briefly describe the changes, fixes, or new features introduced in this PR.

### 🛠️ Issue Fixed

List any issues this PR resolves (e.g., `Fixes #123`).

### 🔍 PR Type

- [X] 💡 Feature
- [x] 🐛 Bug Fix
- [ ] 📃 Documentation
- [x] 🎨 UI Improvements
- [ ] 💻 Code Refactor
- [ ] ✅ Tests
