### PR TITLE
add: request header to accept-encoding to *

### DIFF
--- a/apps/the_monkeys/src/app/api/[[...path]]/route.ts
+++ b/apps/the_monkeys/src/app/api/[[...path]]/route.ts
@@ -11,6 +11,7 @@ async function proxyRequest(req: Request, params?: { path: string[] }) {
   if (authToken && !headers.get('Authorization')) {
     headers.set('Authorization', `Bearer ${authToken.value}`);
   }
+  headers.set('Accept-Encoding', '*');
 
   const clientUrl = new URL(req.url);
   const upstreamPath = params?.path
@@ -29,9 +30,16 @@ async function proxyRequest(req: Request, params?: { path: string[] }) {
       // @ts-ignore: Required for Node.js bi-directional streaming
       duplex: 'half',
     });
+    // console.log("raw headers", response.headers)
+
     const responseHeaders = new Headers(response.headers);
-    responseHeaders.delete('content-encoding');
-    responseHeaders.delete('set-cookie');
+
+    // console.log("before headers >>>>>", responseHeaders)
+    // responseHeaders.delete('content-encoding');
+    // responseHeaders.delete('set-cookie');
+
+    // console.log("After headers, >>>", responseHeaders)
+
     if (typeof response.headers.getSetCookie === 'function') {
       for (const cookie of response.headers.getSetCookie()) {
         responseHeaders.append('Set-Cookie', cookie);

--- a/apps/the_monkeys/src/app/api/[[...path]]/route.ts
+++ b/apps/the_monkeys/src/app/api/[[...path]]/route.ts
@@ -30,16 +30,8 @@ async function proxyRequest(req: Request, params?: { path: string[] }) {
       // @ts-ignore: Required for Node.js bi-directional streaming
       duplex: 'half',
     });
-    // console.log("raw headers", response.headers)
 
     const responseHeaders = new Headers(response.headers);
-
-    // console.log("before headers >>>>>", responseHeaders)
-    // responseHeaders.delete('content-encoding');
-    // responseHeaders.delete('set-cookie');
-
-    // console.log("After headers, >>>", responseHeaders)
-
     if (typeof response.headers.getSetCookie === 'function') {
       for (const cookie of response.headers.getSetCookie()) {
         responseHeaders.append('Set-Cookie', cookie);


### PR DESCRIPTION
### 📃 Why Merge This PR?

Problem: Earlier we were deleting the content-encoding response header and that was confusing the browser how to decompress the compressed that it receives. That was working differently in different environment like netlify and vps.

Solution: Not deleting the content-encoding header in the response from the proxy and adding accept-encoding: * so that cloudflare that we accept all algo of compress. 


### 🔍 PR Type

- [ ] 💡 Feature
- [x] 🐛 Bug Fix
- [ ] 📃 Documentation
- [ ] 🎨 UI Improvements
- [x] 💻 Code Refactor
- [ ] ✅ Tests
