### PR TITLE
Fix: Resolve monorepo build, vitest macOS crashes, broken auth tests,…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules/
 .env.production
 package-lock.json
 .vscode
+.DS_Store
+._*

--- a/apps/the_monkeys/__tests__/src/app/auth/components/ForgotPasswordForm.test.jsx
+++ b/apps/the_monkeys/__tests__/src/app/auth/components/ForgotPasswordForm.test.jsx
@@ -1,215 +1,215 @@
 import ForgotPasswordForm from '@/app/auth/components/forms/ForgotPasswordForm';
 import * as Services from '@/services/auth/auth';
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithProviders } from '../../../../utils';
 
+let routerPushStub = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: routerPushStub,
+  }),
+  useSearchParams: () => ({
+    get: vi.fn(),
+  }),
+}));
+
 describe('ForgotPasswordForm', () => {
   afterEach(() => {
     cleanup();
+    vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it('Shows invalid email error on invalid email', async () => {
     renderWithProviders(<ForgotPasswordForm />);
 
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
+    const submitButton = screen.getByRole('button', { name: /send verification code/i });
+    const emailInput = screen.getByPlaceholderText('Enter email address');
 
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('johndoe@example');
+    await userEvent.type(emailInput, 'johndoe@example');
     await userEvent.click(submitButton);
 
     const emailErrorMessage = await screen.findByText('Invalid email');
-
     expect(emailErrorMessage).toBeDefined();
   });
 
-  it('Shows required error text on values', async () => {
+  it('Shows required error text on empty email submit', async () => {
     renderWithProviders(<ForgotPasswordForm />);
 
-    const submitButton = screen.getByRole('button');
+    const submitButton = screen.getByRole('button', { name: /send verification code/i });
     await userEvent.click(submitButton);
 
     const emailErrorMessage = await screen.findByText('Email is required');
-
     expect(emailErrorMessage).toBeDefined();
   });
 
-  it('Clear button is hidden when field is empty', async () => {
+  it('Clear button behavior', async () => {
     renderWithProviders(<ForgotPasswordForm />);
-    const clearButton = screen.queryByRole('button', { name: 'clear button' });
+    const emailInput = screen.getByPlaceholderText('Enter email address');
 
+    // Initially, no clear button
+    let clearButton = screen.queryByRole('button', { name: 'clear button' });
     expect(clearButton).toBeNull();
-  });
 
-  it('Clear button is visible when field is empty', async () => {
-    renderWithProviders(<ForgotPasswordForm />);
-    const emailInput = screen.getByRole('textbox');
-
+    // Type email, clear button should appear
     await userEvent.type(emailInput, 'john@example.com');
+    clearButton = screen.getByRole('button', { name: 'clear button' });
+    expect(clearButton).toBeDefined();
 
-    screen.getByRole('button', { name: 'clear button' });
-  });
-
-  it('Clear button clears the email field', async () => {
-    renderWithProviders(<ForgotPasswordForm />);
-    const emailInput = screen.getByRole('textbox');
-
-    await userEvent.type(emailInput, 'john@example.com');
-    await userEvent.click(screen.getByRole('button', { name: 'clear button' }));
-
-    expect(emailInput.textContent).toBe('');
-    expect(emailInput.value).toBe('');
-  });
-
-  it('Successful submit', async () => {
-    const spy = vi
-      .spyOn(Services, 'forgotPass')
-      .mockImplementation((values) => ({
-        status: 200,
-        data: {
-          message: 'rest link is sent to your registered email',
-        },
-      }));
-
-    renderWithProviders(<ForgotPasswordForm />);
-
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
-
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('john@doe.com');
-    await userEvent.click(submitButton);
-
-    expect(spy).toHaveBeenCalled();
-    expect(spy).toHaveBeenCalledWith({
-      email: 'john@doe.com',
-    });
-
-    expect(submitButton.textContent).toBe('Submitted Successfully');
-    expect(submitButton.disabled).toBe(true);
-  });
-
-  it('Clicking clear button after successful submit - resets form and button', async () => {
-    const spy = vi
-      .spyOn(Services, 'forgotPass')
-      .mockImplementation((values) => ({
-        status: 200,
-        data: {
-          message: 'rest link is sent to your registered email',
-        },
-      }));
-
-    renderWithProviders(<ForgotPasswordForm />);
-
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
-
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('john@doe.com');
-    await userEvent.click(submitButton);
-
-    expect(spy).toHaveBeenCalled();
-    expect(spy).toHaveBeenCalledWith({
-      email: 'john@doe.com',
-    });
-
-    expect(submitButton.textContent).toBe('Submitted Successfully');
-    expect(submitButton.disabled).toBe(true);
-
-    const clearButton = screen.getByRole('button', { name: 'clear button' });
-
+    // Click clear button, email should be empty and clear button disappears
     await userEvent.click(clearButton);
-
     expect(emailInput.value).toBe('');
-    expect(submitButton.textContent).toBe('Submit');
-    expect(submitButton.disabled).toBe(false);
+    expect(screen.queryByRole('button', { name: 'clear button' })).toBeNull();
   });
 
-  it('Error submit', async () => {
-    renderWithProviders(<ForgotPasswordForm />);
-
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
-
-    const spy = vi.spyOn(Services, 'forgotPass').mockImplementation(() => {
-      throw new Error('test error');
-    });
-
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('john@doe.com');
-    await userEvent.click(submitButton);
-
-    const errorMessage = await screen.findByText(
-      'An unexpected error occurred while submitting the form, please retry again or contact support'
-    );
-
-    expect(spy).toThrowError('test error');
-    expect(errorMessage).not.toBeNull();
-    expect(submitButton.textContent).toBe('Click to retry');
-    expect(submitButton.disabled).toBe(false);
-  });
-
-  it('Clicking clear button after error', async () => {
-    renderWithProviders(<ForgotPasswordForm />);
-
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
-
-    const spy = vi.spyOn(Services, 'forgotPass').mockImplementation(() => {
-      throw new Error('test error');
-    });
-
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('john@doe.com');
-    await userEvent.click(submitButton);
-
-    const errorMessage = await screen.findByText(
-      'An unexpected error occurred while submitting the form, please retry again or contact support'
-    );
-
-    expect(spy).toThrowError('test error');
-    expect(errorMessage).not.toBeNull();
-    expect(submitButton.textContent).toBe('Click to retry');
-    expect(submitButton.disabled).toBe(false);
-
-    const clearButton = screen.getByRole('button', { name: 'clear button' });
-
-    await userEvent.click(clearButton);
-
-    expect(emailInput.value).toBe('');
-    expect(submitButton.textContent).toBe('Submit');
-    expect(submitButton.disabled).toBe(false);
-  });
-
-  it('Editing input field after submitting enables submit button', async () => {
-    renderWithProviders(<ForgotPasswordForm />);
-
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
-
-    const spy = vi
+  it('Successful OTP flow: send email OTP, then verify OTP', async () => {
+    const forgotPassSpy = vi
       .spyOn(Services, 'forgotPass')
-      .mockImplementation((values) => ({
+      .mockResolvedValue({
         status: 200,
-        data: {
-          message: 'rest link is sent to your registered email',
-        },
-      }));
+        data: { message: 'OTP sent successfully' },
+      });
 
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('john@doe.com');
-    await userEvent.click(submitButton);
+    const verifyOTPSpy = vi
+      .spyOn(Services, 'verifyResetOTP')
+      .mockResolvedValue({
+        token: 'fake-reset-token',
+      });
 
-    expect(submitButton.textContent).toBe('Submitted Successfully');
-    expect(submitButton.disabled).toBe(true);
+    renderWithProviders(<ForgotPasswordForm />);
 
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('1');
+    const emailInput = screen.getByPlaceholderText('Enter email address');
+    const sendButton = screen.getByRole('button', { name: /send verification code/i });
 
-    expect(submitButton.textContent).toBe('Submit');
-    expect(submitButton.disabled).toBe(false);
+    await userEvent.type(emailInput, 'john@doe.com');
+    await userEvent.click(sendButton);
+
+    expect(forgotPassSpy).toHaveBeenCalledWith({ email: 'john@doe.com' });
+
+    // Wait for the step to transition to OTP verification
+    const otpInstruction = await screen.findByText(/we sent a 6-digit verification code/i);
+    expect(otpInstruction).toBeDefined();
+
+    // Type the 6-digit OTP code
+    const otpInput = screen.getByPlaceholderText('Enter 6-digit code');
+    await userEvent.type(otpInput, '123456');
+
+    // Submit the OTP form
+    const verifyButton = screen.getByRole('button', { name: /verify code/i });
+    await userEvent.click(verifyButton);
+
+    expect(verifyOTPSpy).toHaveBeenCalledWith({
+      email: 'john@doe.com',
+      otp_code: '123456',
+    });
+
+    await waitFor(() => {
+      expect(routerPushStub).toHaveBeenCalledWith(
+        '/auth/reset-password?token=fake-reset-token&email=john%40doe.com'
+      );
+    });
+  });
+
+  it('Failure in OTP verification shows error toast', async () => {
+    vi.spyOn(Services, 'forgotPass').mockResolvedValue({
+      status: 200,
+      data: { message: 'OTP sent successfully' },
+    });
+
+    const verifyOTPSpy = vi
+      .spyOn(Services, 'verifyResetOTP')
+      .mockRejectedValue(new Error('Invalid code'));
+
+    renderWithProviders(<ForgotPasswordForm />);
+
+    const emailInput = screen.getByPlaceholderText('Enter email address');
+    const sendButton = screen.getByRole('button', { name: /send verification code/i });
+
+    await userEvent.type(emailInput, 'john@doe.com');
+    await userEvent.click(sendButton);
+
+    const otpInput = await screen.findByPlaceholderText('Enter 6-digit code');
+    await userEvent.type(otpInput, '123456');
+
+    const verifyButton = screen.getByRole('button', { name: /verify code/i });
+    await userEvent.click(verifyButton);
+
+    expect(verifyOTPSpy).toHaveBeenCalled();
+
+    // Verify error toast message is displayed
+    const errorToastTitle = await screen.findByText('Invalid code');
+    const errorToastDesc = await screen.findByText('Please check the code and try again');
+    expect(errorToastTitle).toBeDefined();
+    expect(errorToastDesc).toBeDefined();
+  });
+
+  it('Can go back to email step from OTP step', async () => {
+    vi.spyOn(Services, 'forgotPass').mockResolvedValue({
+      status: 200,
+      data: { message: 'OTP sent successfully' },
+    });
+
+    renderWithProviders(<ForgotPasswordForm />);
+
+    const emailInput = screen.getByPlaceholderText('Enter email address');
+    const sendButton = screen.getByRole('button', { name: /send verification code/i });
+
+    await userEvent.type(emailInput, 'john@doe.com');
+    await userEvent.click(sendButton);
+
+    // Wait for the OTP step
+    const changeEmailButton = await screen.findByRole('button', { name: /change email/i });
+    await userEvent.click(changeEmailButton);
+
+    // Expect to be back on the email input step
+    expect(screen.getByPlaceholderText('Enter email address')).toBeDefined();
+  });
+
+  it('Resend Code button cooldown behavior', async () => {
+    vi.useFakeTimers();
+
+    vi.spyOn(Services, 'forgotPass').mockResolvedValue({
+      status: 200,
+      data: { message: 'OTP sent successfully' },
+    });
+
+    renderWithProviders(<ForgotPasswordForm />);
+
+    const emailInput = screen.getByPlaceholderText('Enter email address');
+    const sendButton = screen.getByRole('button', { name: /send verification code/i });
+
+    // Use fireEvent to avoid userEvent timer conflicts
+    fireEvent.change(emailInput, { target: { value: 'john@doe.com' } });
+    fireEvent.click(sendButton);
+
+    // Flush the React Query mutation microtasks inside act
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Check if OTP step is rendered and button is "Resend in 30s"
+    const resendButton = screen.getByRole('button', { name: /resend in 30s/i });
+    expect(resendButton.disabled).toBe(true);
+
+    // Wait 15 seconds (1 second at a time) to let React execute effects sequentially
+    for (let i = 0; i < 15; i++) {
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+    }
+    expect(screen.getByRole('button', { name: /resend in 15s/i })).toBeDefined();
+
+    // Wait another 15 seconds (total 30 seconds elapsed)
+    for (let i = 0; i < 15; i++) {
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+    }
+    const activeResendButton = screen.getByRole('button', { name: /resend code/i });
+    expect(activeResendButton.disabled).toBe(false);
   });
 });

--- a/apps/the_monkeys/src/app/api/[[...path]]/route.ts
+++ b/apps/the_monkeys/src/app/api/[[...path]]/route.ts
@@ -2,7 +2,10 @@ import { cookies } from 'next/headers';
 
 import { API_URL } from '@/constants/api';
 
-async function proxyRequest(req: Request, params?: { path: string[] }) {
+async function proxyRequest(
+  req: Request,
+  { params }: { params?: { path: string[] } } = {}
+) {
   const cookieStore = cookies();
   const authToken = cookieStore.get('mat');
   const apiOrigin = new URL(API_URL!).origin;

--- a/apps/the_monkeys/src/services/api/axiosInstance.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstance.ts
@@ -1,10 +1,13 @@
+import { API_URL } from '@/constants/api';
 import { getAllRequestHeaders } from '@/utils/requestHeaders';
 import axios from 'axios';
 
 import { setupRefreshInterceptor } from './interceptors';
 
+const isServer = typeof window === 'undefined';
+
 const axiosInstance = axios.create({
-  baseURL: '/api/v1',
+  baseURL: isServer ? API_URL || 'https://monkeys.support/api/v1' : '/api/v1',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/src/services/api/axiosInstanceNoAuth.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstanceNoAuth.ts
@@ -1,9 +1,12 @@
+import { API_URL } from '@/constants/api';
 import clientInfo from '@/utils/clientInfo';
 import { getAllRequestHeaders } from '@/utils/requestHeaders';
 import axios from 'axios';
 
+const isServer = typeof window === 'undefined';
+
 const axiosInstanceNoAuth = axios.create({
-  baseURL: '/api/v1',
+  baseURL: isServer ? API_URL || 'https://monkeys.support/api/v1' : '/api/v1',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/src/services/api/axiosInstanceNoAuthV2.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstanceNoAuthV2.ts
@@ -1,8 +1,13 @@
+import { API_URL_V2 } from '@/constants/api';
 import { getAllRequestHeaders } from '@/utils/requestHeaders';
 import axios from 'axios';
 
+const isServer = typeof window === 'undefined';
+
 const axiosInstanceNoAuthV2 = axios.create({
-  baseURL: '/api/v2',
+  baseURL: isServer
+    ? API_URL_V2 || 'https://monkeys.support/api/v2'
+    : '/api/v2',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/src/services/api/axiosInstanceV2.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstanceV2.ts
@@ -1,10 +1,15 @@
+import { API_URL_V2 } from '@/constants/api';
 import { getAllRequestHeaders } from '@/utils/requestHeaders';
 import axios from 'axios';
 
 import { setupRefreshInterceptor } from './interceptors';
 
+const isServer = typeof window === 'undefined';
+
 const axiosInstanceV2 = axios.create({
-  baseURL: '/api/v2',
+  baseURL: isServer
+    ? API_URL_V2 || 'https://monkeys.support/api/v2'
+    : '/api/v2',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/vitest.config.mts
+++ b/apps/the_monkeys/vitest.config.mts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
     environment: 'jsdom',
+    exclude: [...configDefaults.exclude, '**/._*'],
     coverage: {
       provider: 'istanbul',
       exclude: [...configDefaults.coverage.exclude!, '*.config.*'],

--- a/package.json
+++ b/package.json
@@ -20,5 +20,12 @@
 	"packageManager": "pnpm@10.10.0",
 	"dependencies": {
 		"prismjs": "^1.30.0"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"@biomejs/biome",
+			"esbuild",
+			"sharp"
+		]
 	}
 }


### PR DESCRIPTION
### Description
This PR resolves several critical build, configuration, and unit testing errors that prevent the frontend monorepo from building and testing successfully. 

### Key Changes
1. **Auth Test Suite & Cooldown Fixes**:
   * Rewrote `ForgotPasswordForm.test.jsx` to mock `next/navigation` hooks (fixing `expected app router to be mounted` errors).
   * Updated assertions to align with the new step-based Email/OTP verification flow.
   * Utilized sequential fake timer ticks wrapped in React `act` blocks to accurately test the 30-second cooldown without hanging the Vitest engine.

2. **macOS Metadata Exclusion**:
   * Configured Vitest `exclude` patterns in `vitest.config.mts` to ignore macOS `._*` binary files (preventing esbuild syntax parser crashes).
   * Ignored `.DS_Store` and `._*` files in the root `.gitignore`.

3. **Hybrid client/server Axios baseURLs**:
   * Configured Axios configurations (`axiosInstance`, `axiosInstanceNoAuth`, `axiosInstanceV2`, `axiosInstanceNoAuthV2`) to dynamically resolve `baseURL` to the absolute backend API URL when running on the server side (`typeof window === 'undefined'`) and relative routes on the client side. This resolves the `TypeError: Invalid URL` errors during Next.js build-time pre-rendering.

4. **API Proxy handler fix**:
   * Destructured `params` from Next.js's route handler context object in the dynamic `[[...path]]/route.ts` proxy rather than referencing the context argument directly, and formatted the signature for Prettier compliance.

5. **pnpm v10 Compatibility**:
   * Added `onlyBuiltDependencies` for `@biomejs/biome`, `esbuild`, and `sharp` to the root `package.json` to resolve installer security block warnings.

### Verification Results
* `pnpm lint`: Passed cleanly without formatting or linting errors.
* `pnpm test`: All 31 unit tests pass successfully.
* `pnpm build`: Next.js production compilation and static page generation succeed without any `TypeError: Invalid URL` failures.

test results:

<img width="778" height="678" alt="image" src="https://github.com/user-attachments/assets/79b0ebf3-21ac-438d-ad72-f34d89502aa6" />
