### PR TITLE
Fix: Resolve broken ForgotPassword tests and macOS vitest crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules/
 .env.production
 package-lock.json
 .vscode
+.DS_Store
+._*

--- a/apps/the_monkeys/__tests__/src/app/auth/components/ForgotPasswordForm.test.jsx
+++ b/apps/the_monkeys/__tests__/src/app/auth/components/ForgotPasswordForm.test.jsx
@@ -1,215 +1,215 @@
 import ForgotPasswordForm from '@/app/auth/components/forms/ForgotPasswordForm';
 import * as Services from '@/services/auth/auth';
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithProviders } from '../../../../utils';
 
+let routerPushStub = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: routerPushStub,
+  }),
+  useSearchParams: () => ({
+    get: vi.fn(),
+  }),
+}));
+
 describe('ForgotPasswordForm', () => {
   afterEach(() => {
     cleanup();
+    vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it('Shows invalid email error on invalid email', async () => {
     renderWithProviders(<ForgotPasswordForm />);
 
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
+    const submitButton = screen.getByRole('button', { name: /send verification code/i });
+    const emailInput = screen.getByPlaceholderText('Enter email address');
 
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('johndoe@example');
+    await userEvent.type(emailInput, 'johndoe@example');
     await userEvent.click(submitButton);
 
     const emailErrorMessage = await screen.findByText('Invalid email');
-
     expect(emailErrorMessage).toBeDefined();
   });
 
-  it('Shows required error text on values', async () => {
+  it('Shows required error text on empty email submit', async () => {
     renderWithProviders(<ForgotPasswordForm />);
 
-    const submitButton = screen.getByRole('button');
+    const submitButton = screen.getByRole('button', { name: /send verification code/i });
     await userEvent.click(submitButton);
 
     const emailErrorMessage = await screen.findByText('Email is required');
-
     expect(emailErrorMessage).toBeDefined();
   });
 
-  it('Clear button is hidden when field is empty', async () => {
+  it('Clear button behavior', async () => {
     renderWithProviders(<ForgotPasswordForm />);
-    const clearButton = screen.queryByRole('button', { name: 'clear button' });
+    const emailInput = screen.getByPlaceholderText('Enter email address');
 
+    // Initially, no clear button
+    let clearButton = screen.queryByRole('button', { name: 'clear button' });
     expect(clearButton).toBeNull();
-  });
 
-  it('Clear button is visible when field is empty', async () => {
-    renderWithProviders(<ForgotPasswordForm />);
-    const emailInput = screen.getByRole('textbox');
-
+    // Type email, clear button should appear
     await userEvent.type(emailInput, 'john@example.com');
+    clearButton = screen.getByRole('button', { name: 'clear button' });
+    expect(clearButton).toBeDefined();
 
-    screen.getByRole('button', { name: 'clear button' });
-  });
-
-  it('Clear button clears the email field', async () => {
-    renderWithProviders(<ForgotPasswordForm />);
-    const emailInput = screen.getByRole('textbox');
-
-    await userEvent.type(emailInput, 'john@example.com');
-    await userEvent.click(screen.getByRole('button', { name: 'clear button' }));
-
-    expect(emailInput.textContent).toBe('');
-    expect(emailInput.value).toBe('');
-  });
-
-  it('Successful submit', async () => {
-    const spy = vi
-      .spyOn(Services, 'forgotPass')
-      .mockImplementation((values) => ({
-        status: 200,
-        data: {
-          message: 'rest link is sent to your registered email',
-        },
-      }));
-
-    renderWithProviders(<ForgotPasswordForm />);
-
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
-
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('john@doe.com');
-    await userEvent.click(submitButton);
-
-    expect(spy).toHaveBeenCalled();
-    expect(spy).toHaveBeenCalledWith({
-      email: 'john@doe.com',
-    });
-
-    expect(submitButton.textContent).toBe('Submitted Successfully');
-    expect(submitButton.disabled).toBe(true);
-  });
-
-  it('Clicking clear button after successful submit - resets form and button', async () => {
-    const spy = vi
-      .spyOn(Services, 'forgotPass')
-      .mockImplementation((values) => ({
-        status: 200,
-        data: {
-          message: 'rest link is sent to your registered email',
-        },
-      }));
-
-    renderWithProviders(<ForgotPasswordForm />);
-
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
-
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('john@doe.com');
-    await userEvent.click(submitButton);
-
-    expect(spy).toHaveBeenCalled();
-    expect(spy).toHaveBeenCalledWith({
-      email: 'john@doe.com',
-    });
-
-    expect(submitButton.textContent).toBe('Submitted Successfully');
-    expect(submitButton.disabled).toBe(true);
-
-    const clearButton = screen.getByRole('button', { name: 'clear button' });
-
+    // Click clear button, email should be empty and clear button disappears
     await userEvent.click(clearButton);
-
     expect(emailInput.value).toBe('');
-    expect(submitButton.textContent).toBe('Submit');
-    expect(submitButton.disabled).toBe(false);
+    expect(screen.queryByRole('button', { name: 'clear button' })).toBeNull();
   });
 
-  it('Error submit', async () => {
-    renderWithProviders(<ForgotPasswordForm />);
-
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
-
-    const spy = vi.spyOn(Services, 'forgotPass').mockImplementation(() => {
-      throw new Error('test error');
-    });
-
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('john@doe.com');
-    await userEvent.click(submitButton);
-
-    const errorMessage = await screen.findByText(
-      'An unexpected error occurred while submitting the form, please retry again or contact support'
-    );
-
-    expect(spy).toThrowError('test error');
-    expect(errorMessage).not.toBeNull();
-    expect(submitButton.textContent).toBe('Click to retry');
-    expect(submitButton.disabled).toBe(false);
-  });
-
-  it('Clicking clear button after error', async () => {
-    renderWithProviders(<ForgotPasswordForm />);
-
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
-
-    const spy = vi.spyOn(Services, 'forgotPass').mockImplementation(() => {
-      throw new Error('test error');
-    });
-
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('john@doe.com');
-    await userEvent.click(submitButton);
-
-    const errorMessage = await screen.findByText(
-      'An unexpected error occurred while submitting the form, please retry again or contact support'
-    );
-
-    expect(spy).toThrowError('test error');
-    expect(errorMessage).not.toBeNull();
-    expect(submitButton.textContent).toBe('Click to retry');
-    expect(submitButton.disabled).toBe(false);
-
-    const clearButton = screen.getByRole('button', { name: 'clear button' });
-
-    await userEvent.click(clearButton);
-
-    expect(emailInput.value).toBe('');
-    expect(submitButton.textContent).toBe('Submit');
-    expect(submitButton.disabled).toBe(false);
-  });
-
-  it('Editing input field after submitting enables submit button', async () => {
-    renderWithProviders(<ForgotPasswordForm />);
-
-    const submitButton = screen.getByRole('button');
-    const emailInput = screen.getByRole('textbox');
-
-    const spy = vi
+  it('Successful OTP flow: send email OTP, then verify OTP', async () => {
+    const forgotPassSpy = vi
       .spyOn(Services, 'forgotPass')
-      .mockImplementation((values) => ({
+      .mockResolvedValue({
         status: 200,
-        data: {
-          message: 'rest link is sent to your registered email',
-        },
-      }));
+        data: { message: 'OTP sent successfully' },
+      });
 
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('john@doe.com');
-    await userEvent.click(submitButton);
+    const verifyOTPSpy = vi
+      .spyOn(Services, 'verifyResetOTP')
+      .mockResolvedValue({
+        token: 'fake-reset-token',
+      });
 
-    expect(submitButton.textContent).toBe('Submitted Successfully');
-    expect(submitButton.disabled).toBe(true);
+    renderWithProviders(<ForgotPasswordForm />);
 
-    await userEvent.click(emailInput);
-    await userEvent.keyboard('1');
+    const emailInput = screen.getByPlaceholderText('Enter email address');
+    const sendButton = screen.getByRole('button', { name: /send verification code/i });
 
-    expect(submitButton.textContent).toBe('Submit');
-    expect(submitButton.disabled).toBe(false);
+    await userEvent.type(emailInput, 'john@doe.com');
+    await userEvent.click(sendButton);
+
+    expect(forgotPassSpy).toHaveBeenCalledWith({ email: 'john@doe.com' });
+
+    // Wait for the step to transition to OTP verification
+    const otpInstruction = await screen.findByText(/we sent a 6-digit verification code/i);
+    expect(otpInstruction).toBeDefined();
+
+    // Type the 6-digit OTP code
+    const otpInput = screen.getByPlaceholderText('Enter 6-digit code');
+    await userEvent.type(otpInput, '123456');
+
+    // Submit the OTP form
+    const verifyButton = screen.getByRole('button', { name: /verify code/i });
+    await userEvent.click(verifyButton);
+
+    expect(verifyOTPSpy).toHaveBeenCalledWith({
+      email: 'john@doe.com',
+      otp_code: '123456',
+    });
+
+    await waitFor(() => {
+      expect(routerPushStub).toHaveBeenCalledWith(
+        '/auth/reset-password?token=fake-reset-token&email=john%40doe.com'
+      );
+    });
+  });
+
+  it('Failure in OTP verification shows error toast', async () => {
+    vi.spyOn(Services, 'forgotPass').mockResolvedValue({
+      status: 200,
+      data: { message: 'OTP sent successfully' },
+    });
+
+    const verifyOTPSpy = vi
+      .spyOn(Services, 'verifyResetOTP')
+      .mockRejectedValue(new Error('Invalid code'));
+
+    renderWithProviders(<ForgotPasswordForm />);
+
+    const emailInput = screen.getByPlaceholderText('Enter email address');
+    const sendButton = screen.getByRole('button', { name: /send verification code/i });
+
+    await userEvent.type(emailInput, 'john@doe.com');
+    await userEvent.click(sendButton);
+
+    const otpInput = await screen.findByPlaceholderText('Enter 6-digit code');
+    await userEvent.type(otpInput, '123456');
+
+    const verifyButton = screen.getByRole('button', { name: /verify code/i });
+    await userEvent.click(verifyButton);
+
+    expect(verifyOTPSpy).toHaveBeenCalled();
+
+    // Verify error toast message is displayed
+    const errorToastTitle = await screen.findByText('Invalid code');
+    const errorToastDesc = await screen.findByText('Please check the code and try again');
+    expect(errorToastTitle).toBeDefined();
+    expect(errorToastDesc).toBeDefined();
+  });
+
+  it('Can go back to email step from OTP step', async () => {
+    vi.spyOn(Services, 'forgotPass').mockResolvedValue({
+      status: 200,
+      data: { message: 'OTP sent successfully' },
+    });
+
+    renderWithProviders(<ForgotPasswordForm />);
+
+    const emailInput = screen.getByPlaceholderText('Enter email address');
+    const sendButton = screen.getByRole('button', { name: /send verification code/i });
+
+    await userEvent.type(emailInput, 'john@doe.com');
+    await userEvent.click(sendButton);
+
+    // Wait for the OTP step
+    const changeEmailButton = await screen.findByRole('button', { name: /change email/i });
+    await userEvent.click(changeEmailButton);
+
+    // Expect to be back on the email input step
+    expect(screen.getByPlaceholderText('Enter email address')).toBeDefined();
+  });
+
+  it('Resend Code button cooldown behavior', async () => {
+    vi.useFakeTimers();
+
+    vi.spyOn(Services, 'forgotPass').mockResolvedValue({
+      status: 200,
+      data: { message: 'OTP sent successfully' },
+    });
+
+    renderWithProviders(<ForgotPasswordForm />);
+
+    const emailInput = screen.getByPlaceholderText('Enter email address');
+    const sendButton = screen.getByRole('button', { name: /send verification code/i });
+
+    // Use fireEvent to avoid userEvent timer conflicts
+    fireEvent.change(emailInput, { target: { value: 'john@doe.com' } });
+    fireEvent.click(sendButton);
+
+    // Flush the React Query mutation microtasks inside act
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Check if OTP step is rendered and button is "Resend in 30s"
+    const resendButton = screen.getByRole('button', { name: /resend in 30s/i });
+    expect(resendButton.disabled).toBe(true);
+
+    // Wait 15 seconds (1 second at a time) to let React execute effects sequentially
+    for (let i = 0; i < 15; i++) {
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+    }
+    expect(screen.getByRole('button', { name: /resend in 15s/i })).toBeDefined();
+
+    // Wait another 15 seconds (total 30 seconds elapsed)
+    for (let i = 0; i < 15; i++) {
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+    }
+    const activeResendButton = screen.getByRole('button', { name: /resend code/i });
+    expect(activeResendButton.disabled).toBe(false);
   });
 });

--- a/apps/the_monkeys/vitest.config.mts
+++ b/apps/the_monkeys/vitest.config.mts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
     environment: 'jsdom',
+    exclude: [...configDefaults.exclude, '**/._*'],
     coverage: {
       provider: 'istanbul',
       exclude: [...configDefaults.coverage.exclude!, '*.config.*'],

--- a/package.json
+++ b/package.json
@@ -20,5 +20,12 @@
 	"packageManager": "pnpm@10.10.0",
 	"dependencies": {
 		"prismjs": "^1.30.0"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"@biomejs/biome",
+			"esbuild",
+			"sharp"
+		]
 	}
 }


### PR DESCRIPTION
### 1. What was the issue?
There were two issues affecting test stability and local environment setup:
* **Outdated & Broken Unit Tests**: The test suite for `ForgotPasswordForm` was failing locally because of two reasons:
  1. Next.js router hooks (`useRouter`, `useSearchParams`) were not mocked, throwing an `expected app router to be mounted` error.
  2. The component had recently been refactored to a 2-step OTP flow, but the unit tests were still checking for the older single-step UI elements.
* **macOS Metadata Crashes**: Developers working on macOS (specifically when working on external SSDs/volumes) would experience Vitest parser crashes. macOS automatically creates hidden AppleDouble files (prefixed with `._*` e.g., `._ForgotPasswordForm.test.jsx`). The previous glob matched these as test files, causing `esbuild` to fail while trying to compile them.

### 2. How to verify that the issue exists?
* **For Tests**: Checkout the `main` branch and run:
  `pnpm --filter the_monkeys test -- __tests__/src/app/auth/components/ForgotPasswordForm.test.jsx`
  You will see multiple test failures and unmocked router errors.
* **For macOS**: On a Mac, copy a test file to a `._` prefixed binary file and run `pnpm test`. It will crash during test collection.

### 3. What i did to solve it?
* Rewrote `ForgotPasswordForm.test.jsx` from scratch. We mocked `next/navigation` hooks, updated selectors to test Step 1 (Email submission) and Step 2 (OTP code verification), and implemented sequential fake timer advances wrapped in React `act()` blocks to test the 30-second cooldown without hanging the event loop.
* Configured `exclude: [...configDefaults.exclude, '**/._*']` in `vitest.config.mts` to prevent Vitest from picking up hidden macOS metadata files.
* Added `.DS_Store` and `._*` patterns to the root `.gitignore`.
* Approved package builds for `sharp`, `esbuild`, and `@biomejs/biome` in the root `package.json` to support `pnpm v10` non-interactive installs.

### 4. How to verify that it's solved?
Checkout this branch and run:
`pnpm test`
All 31 unit tests across all suites (including `ForgotPasswordForm`) will pass successfully in under 3 seconds.
