### PR TITLE
Fix: Destructure params correctly in catch-all API route proxy

### DIFF
--- a/apps/the_monkeys/src/app/api/[[...path]]/route.ts
+++ b/apps/the_monkeys/src/app/api/[[...path]]/route.ts
@@ -2,7 +2,10 @@ import { cookies } from 'next/headers';
 
 import { API_URL } from '@/constants/api';
 
-async function proxyRequest(req: Request, params?: { path: string[] }) {
+async function proxyRequest(
+  req: Request,
+  { params }: { params?: { path: string[] } } = {}
+) {
   const cookieStore = cookies();
   const authToken = cookieStore.get('mat');
   const apiOrigin = new URL(API_URL!).origin;


### PR DESCRIPTION
### 1. What was the issue?
In Next.js App Router, dynamic route handler parameters are passed inside a context object as the second argument, i.e., `GET(request, { params })`. 
In `src/app/api/[[...path]]/route.ts`, the parameter signature was defined as `proxyRequest(req: Request, params?: { path: string[] })`. This meant `params` was receiving the entire context object `{ params: { path: [...] } }`, resulting in `params.path` resolving to `undefined`. This broke the catch-all dynamic routing and forced the code to fallback to parsing the raw request URL path on every proxy call.

### 2. How to verify that the issue exists?
Add a `console.log(params)` inside the `proxyRequest` function on `main` and hit any API endpoint. You will notice that `params` is logging as `{ params: { path: [...] } }` and that the `params?.path` evaluation resolves to `undefined`, which skips the dynamic route logic and triggers the fallback URL parser.

### 3. What i did to solve it?
Destructured `params` correctly from the Next.js route handler context in the function signature:
```typescript
async function proxyRequest(
  req: Request,
  { params }: { params?: { path: string[] } } = {}
)
