### PR TITLE
Refactor: Use absolute baseURLs on server and relative on client to a…

### DIFF
--- a/apps/the_monkeys/src/services/api/axiosInstance.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstance.ts
@@ -1,10 +1,13 @@
+import { API_URL } from '@/constants/api';
 import { getAllRequestHeaders } from '@/utils/requestHeaders';
 import axios from 'axios';
 
 import { setupRefreshInterceptor } from './interceptors';
 
+const isServer = typeof window === 'undefined';
+
 const axiosInstance = axios.create({
-  baseURL: '/api/v1',
+  baseURL: isServer ? API_URL || 'https://monkeys.support/api/v1' : '/api/v1',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/src/services/api/axiosInstance.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstance.ts
@@ -7,7 +7,7 @@ import { setupRefreshInterceptor } from './interceptors';
 const isServer = typeof window === 'undefined';
 
 const axiosInstance = axios.create({
-  baseURL: isServer ? API_URL || 'https://monkeys.support/api/v1' : '/api/v1',
+  baseURL: isServer ? API_URL : '/api/v1',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/src/services/api/axiosInstanceNoAuth.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstanceNoAuth.ts
@@ -6,7 +6,7 @@ import axios from 'axios';
 const isServer = typeof window === 'undefined';
 
 const axiosInstanceNoAuth = axios.create({
-  baseURL: isServer ? API_URL || 'https://monkeys.support/api/v1' : '/api/v1',
+  baseURL: isServer ? API_URL : '/api/v1',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/src/services/api/axiosInstanceNoAuth.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstanceNoAuth.ts
@@ -1,9 +1,12 @@
+import { API_URL } from '@/constants/api';
 import clientInfo from '@/utils/clientInfo';
 import { getAllRequestHeaders } from '@/utils/requestHeaders';
 import axios from 'axios';
 
+const isServer = typeof window === 'undefined';
+
 const axiosInstanceNoAuth = axios.create({
-  baseURL: '/api/v1',
+  baseURL: isServer ? API_URL || 'https://monkeys.support/api/v1' : '/api/v1',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/src/services/api/axiosInstanceNoAuthV2.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstanceNoAuthV2.ts
@@ -5,9 +5,7 @@ import axios from 'axios';
 const isServer = typeof window === 'undefined';
 
 const axiosInstanceNoAuthV2 = axios.create({
-  baseURL: isServer
-    ? API_URL_V2 || 'https://monkeys.support/api/v2'
-    : '/api/v2',
+  baseURL: isServer ? API_URL_V2 : '/api/v2',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/src/services/api/axiosInstanceNoAuthV2.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstanceNoAuthV2.ts
@@ -1,8 +1,13 @@
+import { API_URL_V2 } from '@/constants/api';
 import { getAllRequestHeaders } from '@/utils/requestHeaders';
 import axios from 'axios';
 
+const isServer = typeof window === 'undefined';
+
 const axiosInstanceNoAuthV2 = axios.create({
-  baseURL: '/api/v2',
+  baseURL: isServer
+    ? API_URL_V2 || 'https://monkeys.support/api/v2'
+    : '/api/v2',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/src/services/api/axiosInstanceV2.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstanceV2.ts
@@ -7,9 +7,7 @@ import { setupRefreshInterceptor } from './interceptors';
 const isServer = typeof window === 'undefined';
 
 const axiosInstanceV2 = axios.create({
-  baseURL: isServer
-    ? API_URL_V2 || 'https://monkeys.support/api/v2'
-    : '/api/v2',
+  baseURL: isServer ? API_URL_V2 : '/api/v2',
   timeout: 30000,
 });
 

--- a/apps/the_monkeys/src/services/api/axiosInstanceV2.ts
+++ b/apps/the_monkeys/src/services/api/axiosInstanceV2.ts
@@ -1,10 +1,15 @@
+import { API_URL_V2 } from '@/constants/api';
 import { getAllRequestHeaders } from '@/utils/requestHeaders';
 import axios from 'axios';
 
 import { setupRefreshInterceptor } from './interceptors';
 
+const isServer = typeof window === 'undefined';
+
 const axiosInstanceV2 = axios.create({
-  baseURL: '/api/v2',
+  baseURL: isServer
+    ? API_URL_V2 || 'https://monkeys.support/api/v2'
+    : '/api/v2',
   timeout: 30000,
 });
 


### PR DESCRIPTION
### 1. What was the issue?
Our Axios instances are configured with a relative `baseURL` of `/api/v1` or `/api/v2` (e.g. `baseURL: '/api/v2'`). While relative URLs are resolved correctly by browser clients, they are invalid on the Node server. When Next.js executes Server Components during pre-rendering/SSR (like fetching the meta-feed on the landing page), Node's fetch engine throws `TypeError: Invalid URL` errors in the build logs.

### 2. How to verify that the issue exists?
Run `pnpm build` on the `main` branch. You will see several errors in the build logs during static page generation:
`Error fetching data: TypeError: Invalid URL`
`input: '/api/v2/blog/meta-feed?limit=30'`

### 3. What i did to solve it?
Updated Axios instances (`axiosInstance`, `axiosInstanceNoAuth`, `axiosInstanceV2`, `axiosInstanceNoAuthV2`) to resolve base URLs dynamically using a hybrid approach:
* **Server-side**: Prepend the absolute `API_URL` or `API_URL_V2` environment variable (with production fallbacks).
* **Client-side**: Use the relative `/api/v1` or `/api/v2` path to proxy requests and handle cookie synchronization correctly.

```typescript
const isServer = typeof window === 'undefined';
const baseURL = isServer ? API_URL  : '/api/v1';
