### PR TITLE
feat: add library tab to profile dropdown menu

### DIFF
--- a/apps/the_monkeys/__tests__/src/components/layout/navbar/profileDropdown.test.jsx
+++ b/apps/the_monkeys/__tests__/src/components/layout/navbar/profileDropdown.test.jsx
@@ -1,0 +1,74 @@
+import ProfileDropdown from '@/components/layout/navbar/profileDropdown';
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../utils';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/services/api/axiosInstance', () => ({
+  default: { get: vi.fn(), post: vi.fn() },
+}));
+
+vi.mock('@/utils/sessionManager', () => ({
+  default: { endSession: vi.fn() },
+}));
+
+const mockSession = {
+  username: 'testuser',
+  first_name: 'Test',
+  last_name: 'User',
+};
+
+const renderAndOpenDropdown = async () => {
+  renderWithProviders(<ProfileDropdown session={mockSession} />);
+  const trigger = screen.getByRole('button');
+  await userEvent.click(trigger);
+};
+
+describe('ProfileDropdown', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('Renders profile trigger with avatar', () => {
+    renderWithProviders(<ProfileDropdown session={mockSession} />);
+
+    const trigger = screen.getByRole('button');
+    expect(trigger).toBeDefined();
+  });
+
+  it('Shows Library link with correct href', async () => {
+    await renderAndOpenDropdown();
+
+    const libraryLink = screen.getByText('Library');
+    expect(libraryLink).toBeDefined();
+    expect(libraryLink.closest('a').getAttribute('href')).toBe('/library');
+  });
+
+  it('Shows Settings link with correct href', async () => {
+    await renderAndOpenDropdown();
+
+    const settingsLink = screen.getByText('Settings');
+    expect(settingsLink).toBeDefined();
+    expect(settingsLink.closest('a').getAttribute('href')).toBe('/settings');
+  });
+
+  it('Shows Logout button', async () => {
+    await renderAndOpenDropdown();
+
+    const logoutButton = screen.getByText('Logout');
+    expect(logoutButton).toBeDefined();
+  });
+
+  it('Shows user name', async () => {
+    await renderAndOpenDropdown();
+
+    const profileLink = screen.getByText('View profile');
+    expect(profileLink).toBeDefined();
+  });
+});

--- a/apps/the_monkeys/src/components/layout/navbar/profileDropdown.tsx
+++ b/apps/the_monkeys/src/components/layout/navbar/profileDropdown.tsx
@@ -70,6 +70,13 @@ const ProfileDropdown = ({ session }: { session?: IUser }) => {
           </Link>
         </DropdownMenuItem>
 
+        <DropdownMenuItem asChild>
+          <Link href={LIBRARY_ROUTE} className='flex w-full items-center gap-2'>
+            <Icon name='RiBookShelf' size={18} />
+            <p className='font-dm_sans text-sm sm:text-base'>Library</p>
+          </Link>
+        </DropdownMenuItem>
+
         {/* <DropdownMenuItem asChild>
           <Link
             href={`${ACTIVITY_ROUTE}?user=${session?.username}`}


### PR DESCRIPTION
Fixes #551 

### 📃 Why Merge This PR?

Adds a **Library** tab to the profile dropdown menu, allowing users to quickly navigate to their library (bookmarks, drafts, scheduled posts) from the profile menu.

Also adds **test coverage** for the `ProfileDropdown` component, which previously had zero tests.

### Changes

- **`apps/the_monkeys/src/components/layout/navbar/profileDropdown.tsx`**: Added Library link with `RiBookShelf` icon after Settings, using existing `LIBRARY_ROUTE` constant.
- **`apps/the_monkeys/__tests__/src/components/layout/navbar/profileDropdown.test.jsx`**: New test file with 5 tests covering the full dropdown (trigger, Library, Settings, Logout, user name).

### Testing

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (5/5)
- [x] No new dependencies
- [x] Follows existing code patterns

### Screenshot / Recording 


https://github.com/user-attachments/assets/d1cf997a-10e1-4519-bc19-411dabdad08b


