### PR TITLE
bug: fixed timestamps rendering in raw format in Topic and For you page

### DIFF
--- a/apps/the_monkeys/__tests__/src/components/cards/blog/TrendingBlogCard.test.jsx
+++ b/apps/the_monkeys/__tests__/src/components/cards/blog/TrendingBlogCard.test.jsx
@@ -1,0 +1,64 @@
+import {
+  TrendingBlogCardLarge,
+  TrendingBlogCardSmall,
+} from '@/components/cards/blog/TrendingBlogCard';
+import { cleanup, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../utils';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('next/image', () => ({
+  default: (props) => <img {...props} />,
+}));
+
+vi.mock('@/utils/imageUtils', () => ({
+  isNonValidBannerImage: () => true,
+}));
+
+const mockBlog = {
+  blog_id: 'test-blog-1',
+  title: 'Test Blog Title',
+  first_image: '',
+  first_paragraph: 'Test description',
+  like_count: 10,
+  owner_account_id: 'user-1',
+  published_time: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+  tags: ['javascript'],
+};
+
+describe('TrendingBlogCardLarge', () => {
+  afterEach(() => cleanup());
+
+  it('Renders formatted relative time instead of raw ISO timestamp', () => {
+    renderWithProviders(<TrendingBlogCardLarge blog={mockBlog} />);
+    expect(screen.getByText('3 hr ago')).toBeDefined();
+  });
+
+  it('Does not render raw ISO timestamp', () => {
+    renderWithProviders(<TrendingBlogCardLarge blog={mockBlog} />);
+    expect(screen.queryByText(mockBlog.published_time)).toBeNull();
+  });
+
+  it('Renders the blog title', () => {
+    renderWithProviders(<TrendingBlogCardLarge blog={mockBlog} />);
+    expect(screen.getByText('Test Blog Title')).toBeDefined();
+  });
+});
+
+describe('TrendingBlogCardSmall', () => {
+  afterEach(() => cleanup());
+
+  it('Renders formatted relative time instead of raw ISO timestamp', () => {
+    renderWithProviders(<TrendingBlogCardSmall blog={mockBlog} />);
+    expect(screen.getByText('3 hr ago')).toBeDefined();
+  });
+
+  it('Does not render raw ISO timestamp', () => {
+    renderWithProviders(<TrendingBlogCardSmall blog={mockBlog} />);
+    expect(screen.queryByText(mockBlog.published_time)).toBeNull();
+  });
+});

--- a/apps/the_monkeys/__tests__/src/lib/utils.test.js
+++ b/apps/the_monkeys/__tests__/src/lib/utils.test.js
@@ -1,0 +1,32 @@
+import { getRelativeTime } from '@/lib/utils';
+import { describe, expect, it } from 'vitest';
+
+describe('getRelativeTime', () => {
+  it('Returns "just now" for timestamps less than 60 seconds ago', () => {
+    const recent = new Date(Date.now() - 30 * 1000).toISOString();
+    expect(getRelativeTime(recent)).toBe('just now');
+  });
+
+  it('Returns minutes ago for timestamps less than 1 hour ago', () => {
+    const minutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(getRelativeTime(minutesAgo)).toBe('5 min ago');
+  });
+
+  it('Returns hours ago for timestamps less than 1 day ago', () => {
+    const hoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+    expect(getRelativeTime(hoursAgo)).toBe('3 hr ago');
+  });
+
+  it('Returns days ago for timestamps less than 30 days ago', () => {
+    const daysAgo = new Date(
+      Date.now() - 7 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    expect(getRelativeTime(daysAgo)).toBe('7 days ago');
+  });
+
+  it('Returns formatted date for timestamps older than 30 days', () => {
+    const old = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+    const result = getRelativeTime(old);
+    expect(result).toMatch(/\w+ \d+, \d{4}/);
+  });
+});

--- a/apps/the_monkeys/src/components/cards/blog/FeedBlogCard.tsx
+++ b/apps/the_monkeys/src/components/cards/blog/FeedBlogCard.tsx
@@ -15,6 +15,7 @@ import {
 import { UserInfoCardShowcase } from '@/components/user/userInfo';
 import { LIVE_URL } from '@/constants/api';
 import { BLOG_ROUTE, TOPIC_ROUTE } from '@/constants/routeConstants';
+import { getRelativeTime } from '@/lib/utils';
 import { BlogCardData } from '@/services/blog/blogTypes';
 import { isNonValidBannerImage } from '@/utils/imageUtils';
 
@@ -215,7 +216,10 @@ const ListCard = ({ blog, showBookmark = false }: CardProps) => {
 
         <div className='w-full flex flex-col justify-between gap-[10px]'>
           <div>
-            <UserInfoCardShowcase authorID={authorId} date={date} />
+            <UserInfoCardShowcase
+              authorID={authorId}
+              date={date ? getRelativeTime(date) : undefined}
+            />
             <Link href={blogURL} className='w-full'>
               <BlogTitle
                 className='pt-2 font-semibold text-[1.12rem] leading-[1.4] hover:underline underline-offset-2 line-clamp-2'

--- a/apps/the_monkeys/src/components/cards/blog/TrendingBlogCard.tsx
+++ b/apps/the_monkeys/src/components/cards/blog/TrendingBlogCard.tsx
@@ -11,6 +11,7 @@ import {
 import { UserInfoCardShowcase } from '@/components/user/userInfo';
 import { LIVE_URL } from '@/constants/api';
 import { BLOG_ROUTE, TOPIC_ROUTE } from '@/constants/routeConstants';
+import { getRelativeTime } from '@/lib/utils';
 import { MetaBlog } from '@/services/blog/blogTypes';
 import { isNonValidBannerImage } from '@/utils/imageUtils';
 import { purifyHTMLString } from '@/utils/purifyHTML';
@@ -18,7 +19,7 @@ import { purifyHTMLString } from '@/utils/purifyHTML';
 export const TrendingBlogCardLarge = ({ blog }: { blog: MetaBlog }) => {
   const authorId = blog?.owner_account_id;
   const blogId = blog?.blog_id;
-  const date = blog?.published_time;
+  const date = blog?.published_time ? getRelativeTime(blog.published_time) : '';
 
   const titleContent = purifyHTMLString(blog?.title);
   const descriptionContent = blog?.first_paragraph;
@@ -94,7 +95,7 @@ export const TrendingBlogCardLarge = ({ blog }: { blog: MetaBlog }) => {
 export const TrendingBlogCardSmall = ({ blog }: { blog: MetaBlog }) => {
   const authorId = blog?.owner_account_id;
   const blogId = blog?.blog_id;
-  const date = blog?.published_time;
+  const date = blog?.published_time ? getRelativeTime(blog.published_time) : '';
 
   const titleContent = purifyHTMLString(blog?.title);
   const descriptionContent = purifyHTMLString(blog?.first_paragraph);


### PR DESCRIPTION
Fixes #550 

## 📃 Why Merge This PR?
fix: Display relative timestamps instead of raw ISO dates on blog cards

## Description
Replaces raw ISO date strings (e.g. `2025-06-29T10:30:00.000Z`) with human-readable relative timestamps (e.g. `2 hours ago`) on `TrendingBlogCard` and `FeedBlogCard` list variants.

This is consistent with how `ProfileBlogCard` and `FeedListItem` already display dates, and resolves the UI inconsistency described in Issue #550 .

## Changes Made
- **`TrendingBlogCard.tsx`** — Both `TrendingBlogCardLarge` and `TrendingBlogCardSmall` now wrap `blog.published_time` through `getRelativeTime()` before passing it to `UserInfoCardShowcase`'s `date` prop.
- **`FeedBlogCard.tsx`** — The `ListCard` variant now formats the date via `getRelativeTime()`.
- **`__tests__/src/lib/utils.test.js`** — 5 tests for `getRelativeTime` (just now, minutes, hours, days, old date).
- **`__tests__/src/components/cards/blog/TrendingBlogCard.test.jsx`** — 5 tests verifying formatted time renders and raw ISO is not displayed.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Testing
- [x] All new and existing tests pass
- [x] Lint passes clean

## Checklist
- [x]  Follows the project's coding conventions
- [x] The changes generate no new warnings

## Screenshots

### Before
<img width="2836" height="1512" alt="image" src="https://github.com/user-attachments/assets/0ae5a374-42d6-48bd-aae9-d4a056f0c832" />

<img width="2828" height="1412" alt="image" src="https://github.com/user-attachments/assets/a71d88a4-8039-43e3-832b-a2c6d039abe6" />

### After

<img width="1915" height="1077" alt="image" src="https://github.com/user-attachments/assets/9bfa253a-4e83-4238-9ea2-a57f8fd99176" />

<img width="1893" height="1075" alt="image" src="https://github.com/user-attachments/assets/71053d0b-70cc-43a9-8ca6-d2a219d10e1c" />





