### PR TITLE
bug: fixed url encoded tags appearing in topic page

### DIFF
--- a/apps/the_monkeys/__tests__/src/utils/topicUtils.test.js
+++ b/apps/the_monkeys/__tests__/src/utils/topicUtils.test.js
@@ -1,0 +1,56 @@
+import { createTopicUrl, slugToTopic, topicToSlug } from '@/utils/topicUtils';
+import { describe, expect, it } from 'vitest';
+
+describe('topicToSlug', () => {
+  it('Converts topic name with spaces to hyphenated slug', () => {
+    expect(topicToSlug('machine learning')).toBe('machine-learning');
+  });
+
+  it('Lowercases topic names', () => {
+    expect(topicToSlug('Artificial Intelligence')).toBe(
+      'artificial-intelligence'
+    );
+  });
+
+  it('Removes special characters', () => {
+    expect(topicToSlug('node.js & react!')).toBe('nodejs-react');
+  });
+
+  it('Collapses multiple hyphens', () => {
+    expect(topicToSlug('a   b')).toBe('a-b');
+  });
+
+  it('Trims leading and trailing hyphens', () => {
+    expect(topicToSlug(' hello world ')).toBe('hello-world');
+  });
+
+  it('Returns empty string for falsy input', () => {
+    expect(topicToSlug('')).toBe('');
+    expect(topicToSlug(null)).toBe('');
+    expect(topicToSlug(undefined)).toBe('');
+  });
+
+  it('Is idempotent for already-slugified input', () => {
+    expect(topicToSlug('machine-learning')).toBe('machine-learning');
+  });
+});
+
+describe('slugToTopic', () => {
+  it('Converts slug to title-cased topic name', () => {
+    expect(slugToTopic('machine-learning')).toBe('Machine Learning');
+  });
+
+  it('Handles single word slugs', () => {
+    expect(slugToTopic('javascript')).toBe('Javascript');
+  });
+
+  it('Returns empty string for falsy input', () => {
+    expect(slugToTopic('')).toBe('');
+  });
+});
+
+describe('createTopicUrl', () => {
+  it('Returns correct URL path for a topic', () => {
+    expect(createTopicUrl('machine learning')).toBe('/topics/machine-learning');
+  });
+});

--- a/apps/the_monkeys/src/components/cards/blog/FeedBlogCard.tsx
+++ b/apps/the_monkeys/src/components/cards/blog/FeedBlogCard.tsx
@@ -18,6 +18,7 @@ import { BLOG_ROUTE, TOPIC_ROUTE } from '@/constants/routeConstants';
 import { getRelativeTime } from '@/lib/utils';
 import { BlogCardData } from '@/services/blog/blogTypes';
 import { isNonValidBannerImage } from '@/utils/imageUtils';
+import { topicToSlug } from '@/utils/topicUtils';
 
 interface CardProps {
   blog: BlogCardData;
@@ -57,7 +58,7 @@ const ArticleTag = ({
   }
   return (
     <Link
-      href={`${TOPIC_ROUTE}/${tag}`}
+      href={`${TOPIC_ROUTE}/${topicToSlug(tag)}`}
       target={openInNewTab ? '_blank' : undefined}
       className={className}
     >

--- a/apps/the_monkeys/src/components/cards/blog/ProfileBlogCard.tsx
+++ b/apps/the_monkeys/src/components/cards/blog/ProfileBlogCard.tsx
@@ -19,6 +19,7 @@ import { getRelativeTime } from '@/lib/utils';
 import { MetaBlog } from '@/services/blog/blogTypes';
 import { isNonValidBannerImage } from '@/utils/imageUtils';
 import { purifyHTMLString } from '@/utils/purifyHTML';
+import { topicToSlug } from '@/utils/topicUtils';
 
 export const ProfileBlogCard = ({
   blog,
@@ -106,7 +107,7 @@ export const ProfileBlogCard = ({
               {blog?.tags.length ? (
                 <div className='w-fit flex items-center gap-1'>
                   <Link
-                    href={`${TOPIC_ROUTE}/${blog?.tags[0]}`}
+                    href={`${TOPIC_ROUTE}/${topicToSlug(blog?.tags[0])}`}
                     target='_blank'
                     className='shrink-0 font-medium text-sm text-brand-orange capitalize hover:underline'
                   >

--- a/apps/the_monkeys/src/components/cards/blog/TrendingBlogCard.tsx
+++ b/apps/the_monkeys/src/components/cards/blog/TrendingBlogCard.tsx
@@ -15,6 +15,7 @@ import { getRelativeTime } from '@/lib/utils';
 import { MetaBlog } from '@/services/blog/blogTypes';
 import { isNonValidBannerImage } from '@/utils/imageUtils';
 import { purifyHTMLString } from '@/utils/purifyHTML';
+import { topicToSlug } from '@/utils/topicUtils';
 
 export const TrendingBlogCardLarge = ({ blog }: { blog: MetaBlog }) => {
   const authorId = blog?.owner_account_id;
@@ -69,7 +70,7 @@ export const TrendingBlogCardLarge = ({ blog }: { blog: MetaBlog }) => {
             <div className='flex items-center gap-2'>
               {blog?.tags.length ? (
                 <Link
-                  href={`${TOPIC_ROUTE}/${blog?.tags[0]}`}
+                  href={`${TOPIC_ROUTE}/${topicToSlug(blog?.tags[0])}`}
                   target='_blank'
                   className='px-3 py-1 bg-brand-orange/10 rounded-full font-inter font-bold text-xs text-brand-orange uppercase tracking-wider hover:bg-brand-orange/20 transition-colors'
                 >
@@ -147,7 +148,7 @@ export const TrendingBlogCardSmall = ({ blog }: { blog: MetaBlog }) => {
             <div className='flex items-center gap-2'>
               {blog?.tags.length ? (
                 <Link
-                  href={`${TOPIC_ROUTE}/${blog?.tags[0]}`}
+                  href={`${TOPIC_ROUTE}/${topicToSlug(blog?.tags[0])}`}
                   target='_blank'
                   className='px-3 py-1 bg-brand-orange/10 rounded-full font-inter font-bold text-xs text-brand-orange uppercase tracking-wider hover:bg-brand-orange/20 transition-colors'
                 >

--- a/apps/the_monkeys/src/components/editorial/EditorialHero.tsx
+++ b/apps/the_monkeys/src/components/editorial/EditorialHero.tsx
@@ -12,6 +12,7 @@ import { BLOG_ROUTE, TOPIC_ROUTE } from '@/constants/routeConstants';
 import { MetaBlog } from '@/services/blog/blogTypes';
 import { isNonValidBannerImage } from '@/utils/imageUtils';
 import { purifyHTMLString } from '@/utils/purifyHTML';
+import { topicToSlug } from '@/utils/topicUtils';
 
 /**
  * Editorial-style hero: full-bleed image as background with category badge
@@ -60,7 +61,7 @@ export const EditorialHero = ({
         {/* Category badge — top-left, sits above the gradient. */}
         {blog?.tags?.[0] ? (
           <Link
-            href={`${TOPIC_ROUTE}/${blog.tags[0]}`}
+            href={`${TOPIC_ROUTE}/${topicToSlug(blog.tags[0])}`}
             className='absolute top-4 left-4 z-20 inline-flex items-center px-3 py-1 bg-brand-orange text-white font-inter font-extrabold text-[11px] uppercase tracking-[0.22em] rounded-sm hover:bg-brand-orange/90 transition-colors'
           >
             {category}

--- a/apps/the_monkeys/src/components/editorial/FeedListItem.tsx
+++ b/apps/the_monkeys/src/components/editorial/FeedListItem.tsx
@@ -11,6 +11,7 @@ import { getRelativeTime } from '@/lib/utils';
 import { MetaBlog } from '@/services/blog/blogTypes';
 import { isNonValidBannerImage } from '@/utils/imageUtils';
 import { purifyHTMLString } from '@/utils/purifyHTML';
+import { topicToSlug } from '@/utils/topicUtils';
 
 import { UserInfoCardShowcase } from '../user/userInfo';
 
@@ -31,7 +32,7 @@ export const FeedListItem = ({ blog }: { blog: MetaBlog }) => {
       <div className='flex-1 min-w-0'>
         {tag ? (
           <Link
-            href={`${TOPIC_ROUTE}/${tag}`}
+            href={`${TOPIC_ROUTE}/${topicToSlug(tag)}`}
             className='inline-block font-inter font-bold text-[11px] text-brand-orange uppercase tracking-[0.15em] hover:opacity-80 transition-opacity'
           >
             {tag}

--- a/apps/the_monkeys/src/components/editorial/HorizontalFeatureCard.tsx
+++ b/apps/the_monkeys/src/components/editorial/HorizontalFeatureCard.tsx
@@ -12,6 +12,7 @@ import { getRelativeTime } from '@/lib/utils';
 import { MetaBlog } from '@/services/blog/blogTypes';
 import { isNonValidBannerImage } from '@/utils/imageUtils';
 import { purifyHTMLString } from '@/utils/purifyHTML';
+import { topicToSlug } from '@/utils/topicUtils';
 
 /**
  * Side-by-side feature: image on the left, category + title + excerpt on
@@ -50,7 +51,7 @@ export const HorizontalFeatureCard = ({ blog }: { blog: MetaBlog }) => {
         <div className='flex flex-col p-5 sm:p-6'>
           {blog?.tags?.[0] ? (
             <Link
-              href={`${TOPIC_ROUTE}/${blog.tags[0]}`}
+              href={`${TOPIC_ROUTE}/${topicToSlug(blog.tags[0])}`}
               className='inline-block self-start font-inter font-extrabold text-[11px] uppercase tracking-[0.22em] text-brand-orange hover:underline'
             >
               {category}

--- a/apps/the_monkeys/src/components/editorial/MinimalBlogCard.tsx
+++ b/apps/the_monkeys/src/components/editorial/MinimalBlogCard.tsx
@@ -5,6 +5,7 @@ import BlogActionBar from '@/components/editorial/BlogActionBar';
 import { BLOG_ROUTE, TOPIC_ROUTE } from '@/constants/routeConstants';
 import { MetaBlog } from '@/services/blog/blogTypes';
 import { purifyHTMLString } from '@/utils/purifyHTML';
+import { topicToSlug } from '@/utils/topicUtils';
 
 /**
  * Bordered, image-less card showing just category label + title.
@@ -29,7 +30,7 @@ export const MinimalBlogCard = ({
     <article className='h-full group p-4 sm:p-5 rounded-md  transition-colors bg-background-light dark:bg-background-dark'>
       {tag ? (
         <Link
-          href={`${TOPIC_ROUTE}/${tag}`}
+          href={`${TOPIC_ROUTE}/${topicToSlug(tag)}`}
           className='inline-block font-inter font-bold text-[11px] text-brand-orange uppercase tracking-[0.15em] hover:opacity-80 transition-opacity'
         >
           {display}


### PR DESCRIPTION
Fixes #554 

## 📃 Why Merge This PR?

When clicking a blog tag, the topic page URL included URL-encoded characters (e.g., `%20` for spaces) instead of clean, readable slugs. This happened because raw tag values with spaces (e.g., `"machine learning"`) were inserted directly into the URL path, causing the browser to encode them.

This fix wraps all tag values with `topicToSlug()` before constructing the URL, producing clean paths like `/topics/machine-learning` instead of `/topics/machine%20learning`.

The topic page already converts slugs back to human-readable names via `slugToTopic()` before making API calls, so the API continues to receive the correct tag values (e.g., `"Machine Learning"`).

## Changes Made
- **`FeedBlogCard.tsx`** — `ArticleTag` component: wrapped tag with `topicToSlug()`
- **`TrendingBlogCard.tsx`** — Both `TrendingBlogCardLarge` and `TrendingBlogCardSmall`: wrapped `blog?.tags[0]` with `topicToSlug()`
- **`ProfileBlogCard.tsx`** — Same pattern
- **`MinimalBlogCard.tsx`** — Same pattern
- **`HorizontalFeatureCard.tsx`** — Same pattern
- **`FeedListItem.tsx`** — Same pattern
- **`EditorialHero.tsx`** — Same pattern
- **`__tests__/src/utils/topicUtils.test.js`** — New test file with 11 tests for `topicToSlug`, `slugToTopic`, and `createTopicUrl`

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] All new and existing tests pass (11 new tests for `topicUtils`)
- [x] Lint passes clean
- [x] Builds Successfully 

## Screenshots

### Before

<img width="2834" height="1700" alt="image" src="https://github.com/user-attachments/assets/d83dfde6-b083-49c5-a353-f79bea7d002d" />

### After

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d64e8c51-307f-4e22-b672-4d8f5ae12159" />

