### PR TITLE
fix: enable editing of post title and description in publish drawer (#522)

### DIFF
--- a/apps/the_monkeys/src/app/edit/[blogId]/page.tsx
+++ b/apps/the_monkeys/src/app/edit/[blogId]/page.tsx
@@ -486,6 +486,7 @@ const EditPage = ({ params }: { params: { blogId: string } }) => {
                 topics={blogTopics}
                 setTopics={setBlogTopics}
                 data={data}
+                setData={setData}
                 isPublishing={blogPublishLoading}
                 handlePublish={handlePublishStep}
                 handleSchedule={handleScheduleStep}

--- a/apps/the_monkeys/src/components/blog/actions/PublishBlogDrawer.tsx
+++ b/apps/the_monkeys/src/components/blog/actions/PublishBlogDrawer.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import FormSearchSelect from '@/components/FormSearchSelect';
+import Icon from '@/components/icon';
 import { Loader } from '@/components/loader';
 import { BLOG_TOPICS_MAX_COUNT } from '@/constants/topics';
 import { useScheduleState } from '@/hooks/blog/schedule/useScheduleState';
@@ -16,9 +17,11 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from '@the-monkeys/ui/atoms/drawer';
+import { Input } from '@the-monkeys/ui/atoms/input';
 import { Label } from '@the-monkeys/ui/atoms/label';
 import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
 import { Switch } from '@the-monkeys/ui/atoms/switch';
+import { TextArea } from '@the-monkeys/ui/atoms/text-area';
 import { twMerge } from 'tailwind-merge';
 
 import ScheduleDateTimePicker from '../ScheduleDateTimePicker';
@@ -28,6 +31,7 @@ interface PublishBlogDrawerProps {
   topics: string[];
   setTopics: React.Dispatch<React.SetStateAction<string[]>>;
   data: OutputData | null;
+  setData?: React.Dispatch<React.SetStateAction<OutputData | null>>;
   handlePublish: () => void;
   handleSchedule?: (scheduleTime: string, timezone: string) => void;
   isPublishing: boolean;
@@ -41,7 +45,7 @@ const INVALID_IMAGE_EXTENSIONS = ['gif', 'apng'];
  */
 const extractBlogPreview = (data: OutputData | null) => {
   const title =
-    data?.blocks.find((block) => block.id === 'title')?.data.text || 'No Title';
+    data?.blocks.find((block) => block.id === 'title')?.data.text ?? '';
 
   const contentBlock = data?.blocks.find((block) => block.type === 'paragraph');
   const description = contentBlock?.data.text ?? 'No Description';
@@ -76,6 +80,7 @@ export const PublishBlogDrawer = ({
   topics,
   setTopics,
   data,
+  setData,
   handlePublish,
   handleSchedule,
   isPublishing,
@@ -83,6 +88,8 @@ export const PublishBlogDrawer = ({
   const { topics: allTopics } = useGetAllTopics();
 
   const [isScheduleMode, setIsScheduleMode] = useState(false);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
 
   const {
     scheduleDate,
@@ -96,6 +103,62 @@ export const PublishBlogDrawer = ({
 
   const { title, description, imageUrl, showImageWarning } =
     extractBlogPreview(data);
+
+  const updateTitle = (newTitle: string) => {
+    if (!setData) return;
+    setData((prev) => {
+      if (!prev) return prev;
+      const updatedBlocks = prev.blocks.map((block) => {
+        if (block.id === 'title') {
+          return {
+            ...block,
+            data: {
+              ...block.data,
+              text: newTitle,
+            },
+          };
+        }
+        return block;
+      });
+      return {
+        ...prev,
+        blocks: updatedBlocks,
+      };
+    });
+  };
+
+  const updateDescription = (newDescription: string) => {
+    if (!setData) return;
+    setData((prev) => {
+      if (!prev) return prev;
+      const paragraphIndex = prev.blocks.findIndex(
+        (block) => block.type === 'paragraph'
+      );
+      const updatedBlocks = [...prev.blocks];
+      if (paragraphIndex !== -1) {
+        updatedBlocks[paragraphIndex] = {
+          ...updatedBlocks[paragraphIndex],
+          data: {
+            ...updatedBlocks[paragraphIndex].data,
+            text: newDescription,
+          },
+        };
+      } else {
+        const newParagraphBlock = {
+          id: `para-${Date.now()}`,
+          type: 'paragraph',
+          data: {
+            text: newDescription,
+          },
+        };
+        updatedBlocks.splice(1, 0, newParagraphBlock);
+      }
+      return {
+        ...prev,
+        blocks: updatedBlocks,
+      };
+    });
+  };
 
   const defaultTopics = topics.map((topic) => ({
     value: topic,
@@ -169,21 +232,152 @@ export const PublishBlogDrawer = ({
                   )}
                 </div>
 
-                <div className='space-y-3'>
-                  <div className='space-y-1'>
-                    <Label className='text-sm opacity-90'>Title</Label>
-                    <BlogTitle
-                      className='font-semibold text-[1.12rem] sm:text-[1.25rem] leading-[1.4] line-clamp-2'
-                      title={title}
-                    />
+                <div className='space-y-4'>
+                  <div className='space-y-1.5'>
+                    <div className='flex items-center justify-between'>
+                      <Label className='text-sm opacity-90'>Title</Label>
+                      {setData && !isEditingTitle && (
+                        <button
+                          type='button'
+                          onClick={() => setIsEditingTitle(true)}
+                          className='p-1 text-text-light/60 dark:text-text-dark/60 hover:text-text-light dark:hover:text-text-dark transition-colors rounded-md hover:bg-black/5 dark:hover:bg-white/5'
+                          title='Edit Title'
+                        >
+                          <Icon name='RiPencil' size={14} />
+                        </button>
+                      )}
+                    </div>
+
+                    {isEditingTitle && setData ? (
+                      <div className='flex items-center gap-2'>
+                        <Input
+                          value={title}
+                          onChange={(e) => updateTitle(e.target.value)}
+                          onBlur={() => setIsEditingTitle(false)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                              setIsEditingTitle(false);
+                            }
+                          }}
+                          autoFocus
+                          className='w-full text-[1.12rem] sm:text-[1.25rem] font-semibold font-newsreader bg-background-light dark:bg-background-dark'
+                          placeholder='Enter post title...'
+                        />
+                        <button
+                          type='button'
+                          onMouseDown={(e) => {
+                            // Prevent blur from firing before onClick
+                            e.preventDefault();
+                          }}
+                          onClick={() => setIsEditingTitle(false)}
+                          className='p-2 text-alert-green hover:bg-alert-green/10 transition-colors rounded-md flex-shrink-0'
+                          title='Save'
+                        >
+                          <Icon name='RiCheck' size={18} />
+                        </button>
+                      </div>
+                    ) : (
+                      <div
+                        onClick={() => setData && setIsEditingTitle(true)}
+                        className={twMerge(
+                          'group relative flex items-center justify-between w-full text-[1.12rem] sm:text-[1.25rem] font-semibold font-newsreader capitalize tracking-tight py-2 px-3 rounded-md border border-transparent transition-all min-h-[42px]',
+                          setData
+                            ? 'hover:bg-black/5 dark:hover:bg-white/5 hover:border-border-light dark:hover:border-border-dark cursor-pointer'
+                            : ''
+                        )}
+                      >
+                        <span
+                          className={twMerge(
+                            'w-full break-words',
+                            title === 'No Title' || !title
+                              ? 'text-text-light/40 dark:text-text-dark/40 font-normal'
+                              : 'text-text-light dark:text-text-dark'
+                          )}
+                        >
+                          {title || 'Untitled Post'}
+                        </span>
+                        {setData && (
+                          <Icon
+                            name='RiPencil'
+                            size={14}
+                            className='opacity-0 group-hover:opacity-100 transition-opacity text-text-light/60 dark:text-text-dark/60 ml-2 flex-shrink-0'
+                          />
+                        )}
+                      </div>
+                    )}
                   </div>
 
-                  <div className='space-y-1'>
-                    <Label className='text-sm opacity-90'>Description</Label>
-                    <BlogDescription
-                      className='text-[0.9rem] sm:text-[1rem] line-clamp-3 sm:line-clamp-2'
-                      description={description}
-                    />
+                  <div className='space-y-1.5'>
+                    <div className='flex items-center justify-between'>
+                      <Label className='text-sm opacity-90'>Description</Label>
+                      {setData && !isEditingDescription && (
+                        <button
+                          type='button'
+                          onClick={() => setIsEditingDescription(true)}
+                          className='p-1 text-text-light/60 dark:text-text-dark/60 hover:text-text-light dark:hover:text-text-dark transition-colors rounded-md hover:bg-black/5 dark:hover:bg-white/5'
+                          title='Edit Description'
+                        >
+                          <Icon name='RiPencil' size={14} />
+                        </button>
+                      )}
+                    </div>
+
+                    {isEditingDescription && setData ? (
+                      <div className='flex items-start gap-2'>
+                        <TextArea
+                          value={
+                            description === 'No Description' ? '' : description
+                          }
+                          onChange={(e) => updateDescription(e.target.value)}
+                          onBlur={() => setIsEditingDescription(false)}
+                          autoFocus
+                          className='w-full text-[0.9rem] sm:text-[1rem] min-h-24 font-normal bg-background-light dark:bg-background-dark'
+                          placeholder='Enter post description...'
+                        />
+                        <button
+                          type='button'
+                          onMouseDown={(e) => {
+                            // Prevent blur from firing before onClick
+                            e.preventDefault();
+                          }}
+                          onClick={() => setIsEditingDescription(false)}
+                          className='p-2 text-alert-green hover:bg-alert-green/10 transition-colors rounded-md flex-shrink-0 mt-2'
+                          title='Save'
+                        >
+                          <Icon name='RiCheck' size={18} />
+                        </button>
+                      </div>
+                    ) : (
+                      <div
+                        onClick={() => setData && setIsEditingDescription(true)}
+                        className={twMerge(
+                          'group relative flex items-start justify-between w-full text-[0.9rem] sm:text-[1rem] font-normal leading-[1.4] py-2 px-3 rounded-md border border-transparent transition-all min-h-[60px]',
+                          setData
+                            ? 'hover:bg-black/5 dark:hover:bg-white/5 hover:border-border-light dark:hover:border-border-dark cursor-pointer'
+                            : ''
+                        )}
+                      >
+                        <p
+                          className={twMerge(
+                            'whitespace-pre-wrap break-words w-full',
+                            description === 'No Description' || !description
+                              ? 'text-text-light/40 dark:text-text-dark/40'
+                              : 'text-text-light/90 dark:text-text-dark/90'
+                          )}
+                        >
+                          {description === 'No Description' || !description
+                            ? 'Enter post description...'
+                            : description}
+                        </p>
+                        {setData && (
+                          <Icon
+                            name='RiPencil'
+                            size={14}
+                            className='opacity-0 group-hover:opacity-100 transition-opacity text-text-light/60 dark:text-text-dark/60 ml-2 mt-1 flex-shrink-0'
+                          />
+                        )}
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/apps/the_monkeys/src/components/editor/index.tsx
+++ b/apps/the_monkeys/src/components/editor/index.tsx
@@ -42,6 +42,7 @@ const Editor: FC<EditorProps> = React.memo(function Editor({
   const editorInstance = useRef<EditorJS | null>(null);
   const prevFileUrls = useRef<Set<string>>(extractFileUrls(data?.blocks || []));
   const debounceTimer = useRef<NodeJS.Timeout | null>(null);
+  const localDataRef = useRef<OutputData | null>(data);
 
   // Pre-calculate the config based on the blogId
   const editorConfig = useMemo(() => getEditorConfig(blogId), [blogId]);
@@ -58,6 +59,7 @@ const Editor: FC<EditorProps> = React.memo(function Editor({
           debounceTimer.current = setTimeout(async () => {
             if (onChange) {
               const savedData = await api.saver.save();
+              localDataRef.current = savedData;
 
               // Detect removed file blocks and delete their files from storage.
               const currentUrls = extractFileUrls(savedData.blocks);
@@ -83,6 +85,24 @@ const Editor: FC<EditorProps> = React.memo(function Editor({
       }
     };
   }, [blogId, editorConfig, onChange]);
+
+  // Sync editor data if updated from outside (e.g. from PublishBlogDrawer)
+  useEffect(() => {
+    if (!editorInstance.current || !data) return;
+
+    const isDifferent =
+      !localDataRef.current ||
+      JSON.stringify(data.blocks) !==
+        JSON.stringify(localDataRef.current.blocks);
+
+    if (isDifferent) {
+      editorInstance.current.isReady.then(() => {
+        if (!editorInstance.current) return;
+        editorInstance.current.render(data);
+        localDataRef.current = data;
+      });
+    }
+  }, [data]);
 
   return (
     <div className='w-full px-4 space-y-6' id='editorjs_editor-container'></div>


### PR DESCRIPTION
#### **Description**

This PR fixes the issue where the post title and description could not be edited or customized inside the publishing drawer. It implements inline edit controls with hover indicators and resolves the issue where clearing the input fields reverted the title back to a default value.

Fixes #522

#### **Changes Made**

1.  **Pencil Edit Options (Inline Editing)**:
    
    *   Changed Title and Description to display as static preview texts by default.
        
    *   Added a pencil edit icon next to the field labels and a hover-activated pencil indicator on the text blocks themselves.
        
    *   Clicking either the edit button or the text container toggles inline input/textarea mode.
        
    *   Editing can be saved by clicking the checkmark (RiCheck) button, clicking outside the input container (onBlur), or pressing Enter (for the Title).
        
2.  **Fixed Title Clearing Logic**:
    
    *   Replaced logical OR (|| 'No Title') with nullish coalescing (?? '') in title data extraction. This allows users to completely delete the existing title text and start writing a new one without the input automatically reverting to 'No Title'.
        

#### **How It Was Tested**

*   Checked type definitions and Next.js project building via pnpm run build --filter=the\_monkeys.
    
*   Verified successful page generation

#### **Visual Demo**
[Screencast_20260707_174324.webm](https://github.com/user-attachments/assets/568115a4-dc5b-4e5b-a6ec-48a56941b73e)

