### PR TITLE
Improve featured banner rendering at responsive breakpoints (#582)

### DIFF
--- a/apps/the_monkeys/src/components/blog/getBlogContent.tsx
+++ b/apps/the_monkeys/src/components/blog/getBlogContent.tsx
@@ -117,7 +117,7 @@ export const BlogImage = ({
       alt={title}
       height='500'
       width='800'
-      className={twMerge(className, 'h-full w-full object-cover object-center')}
+      className={twMerge('h-full w-full object-contain', className)}
       quality={100}
       priority
     />
@@ -137,7 +137,7 @@ export const BlogPlaceholderImage = ({
       alt={title}
       height='500'
       width='800'
-      className={twMerge(className, 'h-full w-full object-cover object-center')}
+      className={twMerge('h-full w-full object-cover object-center', className)}
       quality={100}
     />
   );

--- a/apps/the_monkeys/src/components/editorial/HorizontalFeatureCard.tsx
+++ b/apps/the_monkeys/src/components/editorial/HorizontalFeatureCard.tsx
@@ -32,7 +32,7 @@ export const HorizontalFeatureCard = ({ blog }: { blog: MetaBlog }) => {
       <div className='grid grid-cols-1 sm:grid-cols-2'>
         <Link
           href={url}
-          className='group relative block aspect-[4/3] sm:aspect-auto sm:min-h-[280px] bg-gray-100 dark:bg-gray-800 overflow-hidden'
+          className='group relative block aspect-[4/3] sm:aspect-auto sm:min-h-[280px] overflow-hidden'
         >
           {isNonValidBannerImage(image) ? (
             <BlogPlaceholderImage
@@ -40,11 +40,19 @@ export const HorizontalFeatureCard = ({ blog }: { blog: MetaBlog }) => {
               className='group-hover:scale-[1.03] transition-transform duration-700 ease-out'
             />
           ) : (
-            <BlogImage
-              title={title}
-              image={image}
-              className='group-hover:scale-[1.03] transition-transform duration-700 ease-out'
-            />
+            <>
+              <BlogImage
+                title={title}
+                image={image}
+                className='absolute inset-0 object-cover scale-110 blur-2xl opacity-60 pointer-events-none'
+              />
+              <div className='absolute inset-0 bg-black/30 pointer-events-none' />
+              <BlogImage
+                title={title}
+                image={image}
+                className='relative object-contain group-hover:scale-[1.03] transition-transform duration-700 ease-out'
+              />
+            </>
           )}
         </Link>
 


### PR DESCRIPTION
### 📃 Why Merge This PR?

This PR addresses the issue where the featured banner image gets cropped at certain viewport widths, causing important content within the banner to become hidden.

### 🛠️ Issue Fixed

Fixes the-monkeys/the_monkeys#582

### 🔍 Changes

* Updated the featured banner rendering to display the complete image using `object-contain`.
* Added a blurred background using the same image to maintain a visually filled container while preserving the full banner content. (this approach is used by youtube in order to make the vertical thumbnail fit inside a horizontal layout)
* Additionally Updated the `twMerge` argument order in `BlogImage` so parent-provided `className` values correctly override the default Tailwind classes.

### 🧪 Testing

* Verified the issue at the affected viewport widths.
* Confirmed that the full banner remains visible across different screen sizes.

### 🔍 PR Type

- [ ] 💡 Feature
- [X] 🐛 Bug Fix
- \[\] 📃 Documentation
- [X] 🎨 UI Improvements
- [ ] 💻 Code Refactor
- [ ] ✅ Tests

<img src="https://github.com/user-attachments/assets/bf568bb7-e796-496f-9833-9211f4583bd4 " alt="image" width="926" data-linear-height="323" />