### PR TITLE
[Feature]: custom editorjs plugin to tag user in the blog

### DIFF
--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/index.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/index.ts
@@ -1,0 +1,60 @@
+import { API, InlineTool } from '@editorjs/editorjs';
+
+import MentionHandler from './utils/mentionHandler';
+
+export default class MentionUserTool implements InlineTool {
+  private api: API;
+
+  constructor({ api }: { api: API }) {
+    this.api = api;
+    MentionHandler.instance.attach();
+  }
+
+  static get isInline(): boolean {
+    return true;
+  }
+
+  static get title(): string {
+    return 'Mention';
+  }
+
+  static get sanitize() {
+    return {
+      a: {
+        class: true,
+        'data-username': true,
+        'data-id': true,
+        href: true,
+        contenteditable: true,
+      },
+      span: {
+        class: true,
+      },
+      img: {
+        src: true,
+        class: true,
+        alt: true,
+      },
+    };
+  }
+
+  render(): HTMLElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.innerText = '@';
+    button.classList.add(
+      'mention-tool-button',
+      this.api.styles.inlineToolButton
+    );
+    button.setAttribute('aria-label', 'Mention user');
+    return button;
+  }
+
+  surround(range: Range): void {
+    MentionHandler.instance.triggerFromRange(range);
+  }
+
+  checkState(_selection: Selection): boolean {
+    return false;
+  }
+}

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/index.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/index.ts
@@ -15,7 +15,11 @@ export default class MentionUserTool implements InlineTool {
   }
 
   static get title(): string {
-    return 'Mention';
+    return 'Tag User';
+  }
+
+  static get shortcut(): string {
+    return 'CMD+M';
   }
 
   static get sanitize() {
@@ -43,10 +47,10 @@ export default class MentionUserTool implements InlineTool {
     button.type = 'button';
     button.innerText = '@';
     button.classList.add(
-      'mention-tool-button',
-      this.api.styles.inlineToolButton
+      this.api.styles.inlineToolButton,
+      'ce-inline-tool--tag-user'
     );
-    button.setAttribute('aria-label', 'Mention user');
+    button.setAttribute('aria-label', 'Tag user');
     return button;
   }
 

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/index.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/index.ts
@@ -1,4 +1,4 @@
-import { API, InlineTool } from '@editorjs/editorjs';
+import { API, InlineTool } from '@themonkeys/monkeys-editor';
 
 import MentionHandler from './utils/mentionHandler';
 

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/style.css
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/style.css
@@ -114,7 +114,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 2px 8px 2px 4px;
+  padding: 2px 4px;
   margin: 0 2px;
   font-weight: 600;
   border-radius: 30px;

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/style.css
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/style.css
@@ -1,0 +1,135 @@
+:root {
+  --mention-bg: #ffffff;
+  --mention-border: #e5e7eb;
+  --mention-hover: #f3f4f6;
+  --mention-text-primary: #111827;
+  --mention-text-secondary: #6b7280;
+  --mention-error: #ef4444;
+  --mention-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -2px rgba(0, 0, 0, 0.05);
+
+  --mention-tag-bg: #eff6ff;
+  --mention-tag-text: #ff5542;
+  --mention-tag-hover: #dbeafe;
+}
+
+.dark {
+  --mention-bg: #121212;
+  --mention-border: #151515;
+  --mention-hover: #171717;
+  --mention-text-primary: #f9fafb;
+  --mention-text-secondary: #9ca3af;
+  --mention-error: #f87171;
+  --mention-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.5),
+    0 4px 6px -2px rgba(0, 0, 0, 0.3);
+
+  --mention-tag-bg: rgba(59, 130, 246, 0.15);
+  --mention-tag-text: #ff5542;
+  --mention-tag-hover: rgba(59, 130, 246, 0.25);
+}
+
+.mention-dropdown {
+  position: absolute;
+  z-index: 9999;
+  width: 260px;
+  max-height: 240px;
+  overflow-y: auto;
+  background-color: var(--mention-bg);
+  border: 1px solid var(--mention-border);
+  border-radius: 8px;
+  box-shadow: var(--mention-shadow);
+  font-family: system-ui, sans-serif;
+  display: flex;
+  flex-direction: column;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.mention-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  transition: background-color 0.15s ease;
+}
+
+.mention-item:hover,
+.mention-item.active {
+  background-color: var(--mention-hover);
+}
+
+.mention-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.mention-card-avatar img {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+}
+
+.mention-user-info {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.mention-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--mention-text-primary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.mention-username {
+  font-size: 12px;
+  color: var(--mention-text-secondary);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.mention-status {
+  padding: 12px;
+  font-size: 14px;
+  color: var(--mention-text-secondary);
+  text-align: center;
+}
+
+.mention-status.error {
+  color: var(--mention-error);
+}
+
+.mention-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px 2px 4px;
+  margin: 0 2px;
+  font-weight: 600;
+  border-radius: 30px;
+  text-decoration: none !important;
+  line-height: normal;
+  vertical-align: middle;
+  user-select: all;
+}
+
+.mention-tag:hover {
+  text-decoration: underline !important;
+}
+
+.mention-card-details {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/style.css
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/style.css
@@ -28,6 +28,16 @@
   --mention-tag-hover: rgba(59, 130, 246, 0.25);
 }
 
+.ce-inline-tool--tag-user {
+  margin: 0 0 4px 4px;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.ce-inline-tool--tag-user:hover {
+  color: var(--mention-tag-text);
+}
+
 .mention-dropdown {
   position: absolute;
   z-index: 9999;

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/style.css
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/style.css
@@ -49,8 +49,8 @@
 .mention-item {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
+  gap: 0.75rem;
+  padding: 0.625rem 0.75rem;
   cursor: pointer;
   border-left: 3px solid transparent;
   transition: background-color 0.15s ease;
@@ -62,15 +62,15 @@
 }
 
 .mention-avatar {
-  width: 32px;
-  height: 32px;
+  width: 2rem;
+  height: 2rem;
   border-radius: 50%;
   object-fit: cover;
 }
 
 .mention-card-avatar img {
-  width: 20px;
-  height: 20px;
+  width: 1.25rem;
+  height: 1.25rem;
   border-radius: 50%;
   object-fit: cover;
   display: block;
@@ -100,7 +100,7 @@
 }
 
 .mention-status {
-  padding: 12px;
+  padding: 0.75rem;
   font-size: 14px;
   color: var(--mention-text-secondary);
   text-align: center;
@@ -113,11 +113,8 @@
 .mention-tag {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 2px 4px;
-  margin: 0 2px;
-  font-weight: 600;
-  border-radius: 30px;
+  gap: 0.25rem;
+  padding: 0 2px 2px 2px;
   text-decoration: none !important;
   line-height: normal;
   vertical-align: middle;

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
@@ -1,0 +1,339 @@
+import { fetcherV2 } from '@/services/fetcher';
+
+import '../style.css';
+import { MentionUser } from './types';
+
+export default class MentionHandler {
+  private static _instance: MentionHandler | null = null;
+
+  private dropdown: HTMLDivElement | null = null;
+  private debounceTimer: number | null = null;
+  private currentQuery: string = '';
+  private users: MentionUser[] = [];
+  private activeIndex: number = 0;
+  private activeRange: Range | null = null;
+  private queryCache: Map<string, MentionUser[]> = new Map();
+  private attached: boolean = false;
+
+  static get instance(): MentionHandler {
+    if (!MentionHandler._instance) {
+      MentionHandler._instance = new MentionHandler();
+    }
+    return MentionHandler._instance;
+  }
+
+  attach(): void {
+    if (this.attached) return;
+    this.attached = true;
+
+    document.addEventListener('input', this.handleInput);
+    document.addEventListener('keydown', this.handleKeyDown, { capture: true });
+    document.addEventListener('click', (e: MouseEvent) => {
+      if (this.dropdown && !this.dropdown.contains(e.target as Node)) {
+        this.closeDropdown();
+      }
+    });
+  }
+
+  private isInsideAnyEditor(target: EventTarget | null): boolean {
+    if (!target || !(target as HTMLElement).closest) return false;
+    return !!(target as HTMLElement).closest('.codex-editor');
+  }
+
+  private handleInput = (e: Event): void => {
+    if (!this.isInsideAnyEditor(e.target)) return;
+
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return;
+
+    const range = selection.getRangeAt(0);
+    const textContent = range.startContainer.textContent || '';
+    const caretPos = range.startOffset;
+
+    const textBeforeCaret = textContent.slice(0, caretPos);
+    const match = textBeforeCaret.match(/(?:^|\s)@(\w*)$/);
+
+    if (match) {
+      this.currentQuery = match[1];
+      this.activeRange = range.cloneRange();
+
+      const rect = range.getBoundingClientRect();
+      this.showDropdown(rect);
+
+      if (this.currentQuery.length > 0) {
+        this.fetchUsersDebounced(this.currentQuery);
+      } else if (this.dropdown) {
+        this.renderStatus('Type to search users...');
+      }
+    } else {
+      this.closeDropdown();
+    }
+  };
+
+  private handleKeyDown = (e: KeyboardEvent): void => {
+    if (!this.dropdown) return;
+    if (!this.isInsideAnyEditor(e.target)) return;
+
+    if (['ArrowDown', 'ArrowUp', 'Enter', 'Escape'].includes(e.key)) {
+      e.preventDefault();
+      e.stopPropagation();
+    } else {
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      this.activeIndex = (this.activeIndex + 1) % (this.users.length || 1);
+      this.renderUsers();
+    } else if (e.key === 'ArrowUp') {
+      this.activeIndex =
+        (this.activeIndex - 1 + this.users.length) % (this.users.length || 1);
+      this.renderUsers();
+    } else if (e.key === 'Enter') {
+      if (this.users.length > 0) {
+        this.insertMention(this.users[this.activeIndex]);
+      }
+    } else if (e.key === 'Escape') {
+      this.closeDropdown();
+    }
+  };
+
+  /** Triggered by the InlineTool's surround() when the toolbar "@" button is clicked. */
+  triggerFromRange(range: Range): void {
+    const atNode = document.createTextNode('@');
+    range.deleteContents();
+    range.insertNode(atNode);
+    range.setStartAfter(atNode);
+    range.collapse(true);
+
+    const selection = window.getSelection();
+    if (selection) {
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+
+    this.currentQuery = '';
+    this.activeRange = range.cloneRange();
+
+    const rect = range.getBoundingClientRect();
+    this.showDropdown(rect);
+
+    if (this.dropdown) {
+      this.renderStatus('Type to search users...');
+    }
+  }
+
+  private fetchUsersDebounced(query: string): void {
+    if (this.debounceTimer) window.clearTimeout(this.debounceTimer);
+
+    if (!query) {
+      this.users = [];
+      this.renderUsers();
+      return;
+    }
+
+    if (this.queryCache.has(query)) {
+      this.users = this.queryCache.get(query) || [];
+      this.activeIndex = 0;
+      this.renderUsers();
+      return;
+    }
+
+    if (this.dropdown) {
+      this.renderStatus('Searching...');
+    }
+
+    this.debounceTimer = window.setTimeout(async () => {
+      try {
+        const data = await fetcherV2(
+          `user/search?search_term=${encodeURIComponent(query)}&limit=5&offset=0`
+        );
+        const rawUsers = data?.users || [];
+
+        // Validate all user's profile images at once and set a default if not found
+        const fetchedUsers: MentionUser[] = await Promise.all(
+          rawUsers.map(async (user: MentionUser) => {
+            const targetUrl = `/api/v2/storage/profiles/${user?.username}/profile`;
+            let finalAvatarUrl = '/default-profile.svg';
+
+            try {
+              const res = await fetch(targetUrl, { method: 'HEAD' });
+              if (res.ok) {
+                finalAvatarUrl = targetUrl;
+              }
+            } catch (error) {
+              console.warn(
+                `Failed to fetch avatar for ${user?.username}`,
+                error
+              );
+            }
+
+            return {
+              ...user,
+              full_name: [user.first_name, user.last_name]
+                .filter(Boolean)
+                .join(' ')
+                .trim(),
+              avatar_url: finalAvatarUrl,
+            };
+          })
+        );
+
+        this.queryCache.set(query, fetchedUsers);
+        this.users = fetchedUsers;
+        this.activeIndex = 0;
+
+        if (this.dropdown) {
+          this.renderUsers();
+        }
+      } catch (error) {
+        if (this.dropdown) {
+          this.renderStatus('Error fetching users...', true);
+        }
+      }
+    }, 300);
+  }
+
+  private showDropdown(rect: DOMRect): void {
+    if (!this.dropdown) {
+      this.dropdown = document.createElement('div');
+      this.dropdown.className = 'mention-dropdown';
+
+      document.body.appendChild(this.dropdown);
+    }
+
+    this.dropdown.style.position = 'absolute';
+    this.dropdown.style.top = `${rect.bottom + window.scrollY + 8}px`;
+    this.dropdown.style.left = `${rect.left + window.scrollX}px`;
+    this.dropdown.style.zIndex = '9999';
+  }
+
+  private renderUsers(): void {
+    const dropdown = this.dropdown;
+    if (!dropdown) return;
+
+    dropdown.textContent = '';
+
+    if (this.users.length === 0) {
+      const status = document.createElement('div');
+      status.className = 'mention-status';
+      status.textContent = 'No users found';
+      dropdown.appendChild(status);
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+
+    this.users.forEach((user, index) => {
+      const item = document.createElement('div');
+      item.className = `mention-item ${index === this.activeIndex ? 'active' : ''}`;
+
+      const img = document.createElement('img');
+      img.src = user?.avatar_url || '';
+      img.className = 'mention-avatar';
+      img.alt = user?.username;
+
+      const infoContainer = document.createElement('div');
+      infoContainer.className = 'mention-user-info';
+
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'mention-name';
+      nameSpan.textContent = user?.full_name || '';
+
+      const usernameSpan = document.createElement('span');
+      usernameSpan.className = 'mention-username';
+      usernameSpan.textContent = `@${user?.username}`;
+
+      infoContainer.appendChild(nameSpan);
+      infoContainer.appendChild(usernameSpan);
+
+      item.appendChild(img);
+      item.appendChild(infoContainer);
+
+      item.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this.insertMention(user);
+      });
+
+      item.addEventListener('mouseenter', () => {
+        this.activeIndex = index;
+        this.renderUsers();
+      });
+
+      fragment.appendChild(item);
+    });
+
+    dropdown.appendChild(fragment);
+  }
+
+  private insertMention(user: MentionUser): void {
+    if (!this.activeRange) return;
+
+    const selection = window.getSelection();
+    if (!selection) return;
+
+    const mentionNode = document.createElement('a');
+    mentionNode.href = `/${user.username}`;
+    mentionNode.className = 'mention-tag';
+    mentionNode.dataset.username = user.username;
+    mentionNode.dataset.id = user.id;
+    mentionNode.contentEditable = 'false';
+
+    const avatarSpan = document.createElement('span');
+    avatarSpan.className = 'mention-card-avatar';
+
+    const avatarImg = document.createElement('img');
+    avatarImg.src = user?.avatar_url || '';
+    avatarImg.alt = user?.username;
+    avatarSpan.appendChild(avatarImg);
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'mention-card-fullname';
+    nameSpan.textContent = user?.full_name || '';
+
+    mentionNode.appendChild(avatarSpan);
+    mentionNode.appendChild(nameSpan);
+
+    const textNode = this.activeRange.startContainer;
+    const textContent = textNode.textContent || '';
+    const atIndex = textContent.lastIndexOf('@', this.activeRange.startOffset);
+
+    if (atIndex !== -1) {
+      this.activeRange.setStart(textNode, atIndex);
+      this.activeRange.deleteContents();
+      this.activeRange.insertNode(mentionNode);
+
+      const spaceNode = document.createTextNode('\u00A0');
+      mentionNode.parentNode?.insertBefore(spaceNode, mentionNode.nextSibling);
+
+      this.activeRange.setStartAfter(spaceNode);
+      this.activeRange.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(this.activeRange);
+    }
+
+    this.closeDropdown();
+  }
+
+  private renderStatus(message: string, isError: boolean = false): void {
+    if (!this.dropdown) return;
+
+    this.dropdown.textContent = '';
+
+    const statusDiv = document.createElement('div');
+    statusDiv.className = isError ? 'mention-status error' : 'mention-status';
+    statusDiv.textContent = message;
+
+    this.dropdown.appendChild(statusDiv);
+  }
+
+  private closeDropdown(): void {
+    if (this.dropdown) {
+      this.dropdown.remove();
+      this.dropdown = null;
+    }
+    this.currentQuery = '';
+    this.activeRange = null;
+    this.users = [];
+  }
+}

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
@@ -1,6 +1,5 @@
 import { fetcherV2 } from '@/services/fetcher';
 
-/**@ts-ignore */
 import '../style.css';
 import { MentionUser } from './types';
 
@@ -29,12 +28,37 @@ export default class MentionHandler {
 
     document.addEventListener('input', this.handleInput);
     document.addEventListener('keydown', this.handleKeyDown, { capture: true });
-    document.addEventListener('click', (e: MouseEvent) => {
-      if (this.dropdown && !this.dropdown.contains(e.target as Node)) {
-        this.closeDropdown();
-      }
+    document.addEventListener('click', this.handleDocumentClick);
+
+    window.addEventListener('resize', this.updateDropdownPosition);
+    window.addEventListener('scroll', this.updateDropdownPosition, {
+      capture: true,
+      passive: true,
     });
   }
+
+  detach(): void {
+    if (!this.attached) return;
+    this.attached = false;
+
+    document.removeEventListener('input', this.handleInput);
+    document.removeEventListener('keydown', this.handleKeyDown, {
+      capture: true,
+    });
+    document.removeEventListener('click', this.handleDocumentClick);
+    window.removeEventListener('resize', this.updateDropdownPosition);
+    window.removeEventListener('scroll', this.updateDropdownPosition, {
+      capture: true,
+    });
+
+    this.closeDropdown();
+  }
+
+  private handleDocumentClick = (e: MouseEvent): void => {
+    if (this.dropdown && !this.dropdown.contains(e.target as Node)) {
+      this.closeDropdown();
+    }
+  };
 
   private isInsideAnyEditor(target: EventTarget | null): boolean {
     if (!target || !(target as HTMLElement).closest) return false;
@@ -98,7 +122,6 @@ export default class MentionHandler {
     }
   };
 
-  /** Triggered by the InlineTool's surround() when the toolbar "@" button is clicked. */
   triggerFromRange(range: Range): void {
     const atNode = document.createTextNode('@');
     range.deleteContents();
@@ -150,7 +173,7 @@ export default class MentionHandler {
         );
         const rawUsers = data?.users || [];
 
-        // Validate all user's profile images at once and set a default if not found
+        /** Validate all user's profile images at once */
         const fetchedUsers: MentionUser[] = await Promise.all(
           rawUsers.map(async (user: MentionUser) => {
             const targetUrl = `/api/v2/storage/profiles/${user?.username}/profile`;
@@ -214,10 +237,19 @@ export default class MentionHandler {
     }
 
     this.dropdown.style.position = 'absolute';
+    this.dropdown.style.zIndex = '9999';
+
+    this.updateDropdownPosition();
+  }
+
+  private updateDropdownPosition = (): void => {
+    if (!this.dropdown || !this.activeRange) return;
+
+    const rect = this.activeRange.getBoundingClientRect();
+
     this.dropdown.style.top = `${rect.bottom + window.scrollY + 8}px`;
     this.dropdown.style.left = `${rect.left + window.scrollX}px`;
-    this.dropdown.style.zIndex = '9999';
-  }
+  };
 
   private handleDropdownInteraction = (e: Event): void => {
     const target = e.target as HTMLElement;
@@ -345,7 +377,7 @@ export default class MentionHandler {
       this.activeRange.deleteContents();
       this.activeRange.insertNode(mentionNode);
 
-      const spaceNode = document.createTextNode('\u00A0');
+      const spaceNode = document.createTextNode(' ');
       mentionNode.parentNode?.insertBefore(spaceNode, mentionNode.nextSibling);
 
       this.activeRange.setStartAfter(spaceNode);
@@ -370,6 +402,11 @@ export default class MentionHandler {
   }
 
   private closeDropdown(): void {
+    if (this.debounceTimer) {
+      window.clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+
     if (this.dropdown) {
       this.dropdown.removeEventListener(
         'mousedown',

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
@@ -1,5 +1,6 @@
 import { fetcherV2 } from '@/services/fetcher';
 
+/**@ts-ignore */
 import '../style.css';
 import { MentionUser } from './types';
 
@@ -83,11 +84,11 @@ export default class MentionHandler {
 
     if (e.key === 'ArrowDown') {
       this.activeIndex = (this.activeIndex + 1) % (this.users.length || 1);
-      this.renderUsers();
+      this.updateActiveItem();
     } else if (e.key === 'ArrowUp') {
       this.activeIndex =
         (this.activeIndex - 1 + this.users.length) % (this.users.length || 1);
-      this.renderUsers();
+      this.updateActiveItem();
     } else if (e.key === 'Enter') {
       if (this.users.length > 0) {
         this.insertMention(this.users[this.activeIndex]);
@@ -198,6 +199,17 @@ export default class MentionHandler {
       this.dropdown = document.createElement('div');
       this.dropdown.className = 'mention-dropdown';
 
+      this.dropdown.addEventListener(
+        'mousedown',
+        this.handleDropdownInteraction
+      );
+      this.dropdown.addEventListener(
+        'touchstart',
+        this.handleDropdownInteraction,
+        { passive: false }
+      );
+      this.dropdown.addEventListener('mouseover', this.handleDropdownHover);
+
       document.body.appendChild(this.dropdown);
     }
 
@@ -205,6 +217,45 @@ export default class MentionHandler {
     this.dropdown.style.top = `${rect.bottom + window.scrollY + 8}px`;
     this.dropdown.style.left = `${rect.left + window.scrollX}px`;
     this.dropdown.style.zIndex = '9999';
+  }
+
+  private handleDropdownInteraction = (e: Event): void => {
+    const target = e.target as HTMLElement;
+    const item = target.closest('.mention-item') as HTMLElement;
+    if (!item) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const index = parseInt(item.dataset.index || '0', 10);
+    const user = this.users[index];
+    if (user) {
+      this.insertMention(user);
+    }
+  };
+
+  private handleDropdownHover = (e: Event): void => {
+    const target = e.target as HTMLElement;
+    const item = target.closest('.mention-item') as HTMLElement;
+    if (!item) return;
+
+    const index = parseInt(item.dataset.index || '0', 10);
+    if (this.activeIndex !== index) {
+      this.activeIndex = index;
+      this.updateActiveItem();
+    }
+  };
+
+  private updateActiveItem(): void {
+    if (!this.dropdown) return;
+    const items = this.dropdown.querySelectorAll('.mention-item');
+    items.forEach((item, index) => {
+      if (index === this.activeIndex) {
+        item.classList.add('active');
+      } else {
+        item.classList.remove('active');
+      }
+    });
   }
 
   private renderUsers(): void {
@@ -249,16 +300,7 @@ export default class MentionHandler {
       item.appendChild(img);
       item.appendChild(infoContainer);
 
-      item.addEventListener('mousedown', (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        this.insertMention(user);
-      });
-
-      item.addEventListener('mouseenter', () => {
-        this.activeIndex = index;
-        this.renderUsers();
-      });
+      item.dataset.index = index.toString();
 
       fragment.appendChild(item);
     });
@@ -329,6 +371,16 @@ export default class MentionHandler {
 
   private closeDropdown(): void {
     if (this.dropdown) {
+      this.dropdown.removeEventListener(
+        'mousedown',
+        this.handleDropdownInteraction
+      );
+      this.dropdown.removeEventListener(
+        'touchstart',
+        this.handleDropdownInteraction
+      );
+      this.dropdown.removeEventListener('mouseover', this.handleDropdownHover);
+
       this.dropdown.remove();
       this.dropdown = null;
     }

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
@@ -1,5 +1,6 @@
 import { fetcherV2 } from '@/services/fetcher';
 
+/** @ts-ignore */
 import '../style.css';
 import { MentionUser } from './types';
 
@@ -347,10 +348,10 @@ export default class MentionHandler {
     if (!selection) return;
 
     const mentionNode = document.createElement('a');
-    mentionNode.href = `/${user.username}`;
+    mentionNode.href = `/${user?.username}`;
     mentionNode.className = 'mention-tag';
-    mentionNode.dataset.username = user.username;
-    mentionNode.dataset.id = user.id;
+    mentionNode.dataset.username = user?.username || '';
+    mentionNode.dataset.id = user?.account_id || '';
     mentionNode.contentEditable = 'false';
 
     const avatarSpan = document.createElement('span');

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
@@ -1,6 +1,5 @@
 import { fetcherV2 } from '@/services/fetcher';
 
-/** @ts-ignore */
 import '../style.css';
 import { MentionUser } from './types';
 
@@ -97,29 +96,37 @@ export default class MentionHandler {
   };
 
   private handleKeyDown = (e: KeyboardEvent): void => {
-    if (!this.dropdown) return;
-    if (!this.isInsideAnyEditor(e.target)) return;
+    if (!this.dropdown || !this.isInsideAnyEditor(e.target)) return;
 
-    if (['ArrowDown', 'ArrowUp', 'Enter', 'Escape'].includes(e.key)) {
-      e.preventDefault();
-      e.stopPropagation();
-    } else {
-      return;
-    }
+    const allowedKeys = ['ArrowDown', 'ArrowUp', 'Enter', 'Escape'];
+    if (!allowedKeys.includes(e.key)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
 
     if (e.key === 'ArrowDown') {
       this.activeIndex = (this.activeIndex + 1) % (this.users.length || 1);
       this.updateActiveItem();
-    } else if (e.key === 'ArrowUp') {
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
       this.activeIndex =
         (this.activeIndex - 1 + this.users.length) % (this.users.length || 1);
       this.updateActiveItem();
-    } else if (e.key === 'Enter') {
+      return;
+    }
+
+    if (e.key === 'Enter') {
       if (this.users.length > 0) {
         this.insertMention(this.users[this.activeIndex]);
       }
-    } else if (e.key === 'Escape') {
+      return;
+    }
+
+    if (e.key === 'Escape') {
       this.closeDropdown();
+      return;
     }
   };
 
@@ -147,6 +154,28 @@ export default class MentionHandler {
     }
   }
 
+  private async fetchUsersList(query: string): Promise<MentionUser[]> {
+    const data = await fetcherV2(
+      `user/search?search_term=${encodeURIComponent(query)}&limit=5&offset=0`
+    );
+    const rawUsers = data?.users || [];
+
+    return await Promise.all(
+      rawUsers.map(async (user: MentionUser) => {
+        const finalAvatarUrl = await this.getVerifiedAvatarUrl(user?.username);
+
+        return {
+          ...user,
+          full_name: [user.first_name, user.last_name]
+            .filter(Boolean)
+            .join(' ')
+            .trim(),
+          avatar_url: finalAvatarUrl,
+        };
+      })
+    );
+  }
+
   private fetchUsersDebounced(query: string): void {
     if (this.debounceTimer) window.clearTimeout(this.debounceTimer);
 
@@ -169,39 +198,7 @@ export default class MentionHandler {
 
     this.debounceTimer = window.setTimeout(async () => {
       try {
-        const data = await fetcherV2(
-          `user/search?search_term=${encodeURIComponent(query)}&limit=5&offset=0`
-        );
-        const rawUsers = data?.users || [];
-
-        /** Validate all user's profile images at once */
-        const fetchedUsers: MentionUser[] = await Promise.all(
-          rawUsers.map(async (user: MentionUser) => {
-            const targetUrl = `/api/v2/storage/profiles/${user?.username}/profile`;
-            let finalAvatarUrl = '/default-profile.svg';
-
-            try {
-              const res = await fetch(targetUrl, { method: 'HEAD' });
-              if (res.ok) {
-                finalAvatarUrl = targetUrl;
-              }
-            } catch (error) {
-              console.warn(
-                `Failed to fetch avatar for ${user?.username}`,
-                error
-              );
-            }
-
-            return {
-              ...user,
-              full_name: [user.first_name, user.last_name]
-                .filter(Boolean)
-                .join(' ')
-                .trim(),
-              avatar_url: finalAvatarUrl,
-            };
-          })
-        );
+        const fetchedUsers = await this.fetchUsersList(query);
 
         this.queryCache.set(query, fetchedUsers);
         this.users = fetchedUsers;
@@ -218,10 +215,37 @@ export default class MentionHandler {
     }, 300);
   }
 
+  private async getVerifiedAvatarUrl(username: string): Promise<string> {
+    const defaultAvatar = '/default-profile.svg';
+
+    if (!username) return defaultAvatar;
+
+    try {
+      const response = await fetch(
+        `/api/v2/storage/profiles/${username}/profile/meta`
+      );
+
+      if (!response.ok) {
+        return defaultAvatar;
+      }
+
+      const data = await response.json();
+
+      if (data && data?.url) {
+        return data?.url;
+      }
+
+      return defaultAvatar;
+    } catch (error) {
+      console.error(`Failed to fetch avatar for ${username}`, error);
+      return defaultAvatar;
+    }
+  }
+
   private showDropdown(rect: DOMRect): void {
     if (!this.dropdown) {
       this.dropdown = document.createElement('div');
-      this.dropdown.className = 'mention-dropdown';
+      this.dropdown.classList.add('mention-dropdown');
 
       this.dropdown.addEventListener(
         'mousedown',
@@ -283,11 +307,7 @@ export default class MentionHandler {
     if (!this.dropdown) return;
     const items = this.dropdown.querySelectorAll('.mention-item');
     items.forEach((item, index) => {
-      if (index === this.activeIndex) {
-        item.classList.add('active');
-      } else {
-        item.classList.remove('active');
-      }
+      item.classList.toggle('active', index === this.activeIndex);
     });
   }
 
@@ -299,7 +319,7 @@ export default class MentionHandler {
 
     if (this.users.length === 0) {
       const status = document.createElement('div');
-      status.className = 'mention-status';
+      status.classList.add('mention-status');
       status.textContent = 'No users found';
       dropdown.appendChild(status);
       return;
@@ -309,22 +329,23 @@ export default class MentionHandler {
 
     this.users.forEach((user, index) => {
       const item = document.createElement('div');
-      item.className = `mention-item ${index === this.activeIndex ? 'active' : ''}`;
+      item.classList.add('mention-item');
+      item.classList.toggle('active', index === this.activeIndex);
 
       const img = document.createElement('img');
-      img.src = user?.avatar_url || '';
-      img.className = 'mention-avatar';
-      img.alt = user?.username;
+      img.src = user?.avatar_url || '/default-profile.svg';
+      img.classList.add('mention-avatar');
+      img.alt = user?.username || '';
 
       const infoContainer = document.createElement('div');
-      infoContainer.className = 'mention-user-info';
+      infoContainer.classList.add('mention-user-info');
 
       const nameSpan = document.createElement('span');
-      nameSpan.className = 'mention-name';
+      nameSpan.classList.add('mention-name');
       nameSpan.textContent = user?.full_name || '';
 
       const usernameSpan = document.createElement('span');
-      usernameSpan.className = 'mention-username';
+      usernameSpan.classList.add('mention-username');
       usernameSpan.textContent = `@${user?.username}`;
 
       infoContainer.appendChild(nameSpan);
@@ -349,21 +370,21 @@ export default class MentionHandler {
 
     const mentionNode = document.createElement('a');
     mentionNode.href = `/${user?.username}`;
-    mentionNode.className = 'mention-tag';
+    mentionNode.classList.add('mention-tag');
     mentionNode.dataset.username = user?.username || '';
     mentionNode.dataset.id = user?.account_id || '';
     mentionNode.contentEditable = 'false';
 
     const avatarSpan = document.createElement('span');
-    avatarSpan.className = 'mention-card-avatar';
+    avatarSpan.classList.add('mention-card-avatar');
 
     const avatarImg = document.createElement('img');
-    avatarImg.src = user?.avatar_url || '';
-    avatarImg.alt = user?.username;
+    avatarImg.src = user?.avatar_url || '/default-profile.svg';
+    avatarImg.alt = user?.username || '';
     avatarSpan.appendChild(avatarImg);
 
     const nameSpan = document.createElement('span');
-    nameSpan.className = 'mention-card-fullname';
+    nameSpan.classList.add('mention-card-fullname');
     nameSpan.textContent = user?.full_name || '';
 
     mentionNode.appendChild(avatarSpan);
@@ -396,7 +417,11 @@ export default class MentionHandler {
     this.dropdown.textContent = '';
 
     const statusDiv = document.createElement('div');
-    statusDiv.className = isError ? 'mention-status error' : 'mention-status';
+    statusDiv.classList.add('mention-status');
+    if (isError) {
+      statusDiv.classList.add('error');
+    }
+
     statusDiv.textContent = message;
 
     this.dropdown.appendChild(statusDiv);

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
@@ -368,27 +368,31 @@ export default class MentionHandler {
     const selection = window.getSelection();
     if (!selection) return;
 
+    const username = user?.username || '';
+    const accountId = user?.account_id || '';
+    const avatarUrl = user?.avatar_url || '/default-profile.svg';
+    const fullName = user?.full_name || '';
+
     const mentionNode = document.createElement('a');
-    mentionNode.href = `/${user?.username}`;
+    mentionNode.href = `/${username}`;
     mentionNode.classList.add('mention-tag');
-    mentionNode.dataset.username = user?.username || '';
-    mentionNode.dataset.id = user?.account_id || '';
+    mentionNode.dataset.username = username;
+    mentionNode.dataset.id = accountId;
     mentionNode.contentEditable = 'false';
 
     const avatarSpan = document.createElement('span');
     avatarSpan.classList.add('mention-card-avatar');
 
     const avatarImg = document.createElement('img');
-    avatarImg.src = user?.avatar_url || '/default-profile.svg';
-    avatarImg.alt = user?.username || '';
-    avatarSpan.appendChild(avatarImg);
+    avatarImg.src = avatarUrl;
+    avatarImg.alt = username;
+    avatarSpan.append(avatarImg);
 
     const nameSpan = document.createElement('span');
     nameSpan.classList.add('mention-card-fullname');
-    nameSpan.textContent = user?.full_name || '';
+    nameSpan.textContent = fullName;
 
-    mentionNode.appendChild(avatarSpan);
-    mentionNode.appendChild(nameSpan);
+    mentionNode.append(avatarSpan, nameSpan);
 
     const textNode = this.activeRange.startContainer;
     const textContent = textNode.textContent || '';
@@ -399,11 +403,12 @@ export default class MentionHandler {
       this.activeRange.deleteContents();
       this.activeRange.insertNode(mentionNode);
 
-      const spaceNode = document.createTextNode(' ');
+      const spaceNode = document.createTextNode('\u00A0');
       mentionNode.parentNode?.insertBefore(spaceNode, mentionNode.nextSibling);
 
-      this.activeRange.setStartAfter(spaceNode);
+      this.activeRange.setStart(spaceNode, 1);
       this.activeRange.collapse(true);
+
       selection.removeAllRanges();
       selection.addRange(this.activeRange);
     }

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/mentionHandler.ts
@@ -134,7 +134,7 @@ export default class MentionHandler {
     const atNode = document.createTextNode('@');
     range.deleteContents();
     range.insertNode(atNode);
-    range.setStartAfter(atNode);
+    range.setStart(atNode, 1);
     range.collapse(true);
 
     const selection = window.getSelection();

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/types.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/types.ts
@@ -1,0 +1,8 @@
+export interface MentionUser {
+  id: string;
+  username: string;
+  first_name: string;
+  last_name?: string;
+  avatar_url?: string;
+  full_name?: string;
+}

--- a/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/types.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TagUserBlock/utils/types.ts
@@ -1,5 +1,5 @@
 export interface MentionUser {
-  id: string;
+  account_id: string;
   username: string;
   first_name: string;
   last_name?: string;

--- a/apps/the_monkeys/src/config/editor/monkeys_editor.config.ts
+++ b/apps/the_monkeys/src/config/editor/monkeys_editor.config.ts
@@ -44,9 +44,6 @@ export const getEditorConfig = (blogId: string): EditorConfig => ({
     },
     mention: {
       class: MentionUserTool,
-      config: {
-        holderId: 'editorjs',
-      },
     },
     delimiter: Delimiter,
     quote: {

--- a/apps/the_monkeys/src/config/editor/monkeys_editor.config.ts
+++ b/apps/the_monkeys/src/config/editor/monkeys_editor.config.ts
@@ -1,11 +1,11 @@
 import CustomCodeTool from '@/components/editor/customBlocks/CodeBlock';
 import CustomList from '@/components/editor/customBlocks/CustomListBlock';
 import CustomEmbed from '@/components/editor/customBlocks/EmbedBlock';
+import MentionUserTool from '@/components/editor/customBlocks/TagUserBlock';
 import axiosInstanceV2 from '@/services/api/axiosInstanceV2';
 import Delimiter from '@editorjs/delimiter';
 import Header from '@editorjs/header';
 import Image from '@editorjs/image';
-import List from '@editorjs/list';
 import Paragraph from '@editorjs/paragraph';
 import Quote from '@editorjs/quote';
 import Table from '@editorjs/table';
@@ -41,6 +41,12 @@ export const getEditorConfig = (blogId: string): EditorConfig => ({
     },
     embed: {
       class: CustomEmbed,
+    },
+    mention: {
+      class: MentionUserTool,
+      config: {
+        holderId: 'editorjs',
+      },
     },
     delimiter: Delimiter,
     quote: {

--- a/apps/the_monkeys/src/config/editor/monkeys_editor_readonly.config.ts
+++ b/apps/the_monkeys/src/config/editor/monkeys_editor_readonly.config.ts
@@ -1,11 +1,11 @@
 import CustomCodeTool from '@/components/editor/customBlocks/CodeBlock';
 import CustomList from '@/components/editor/customBlocks/CustomListBlock';
 import CustomEmbed from '@/components/editor/customBlocks/EmbedBlock';
+import MentionUserTool from '@/components/editor/customBlocks/TagUserBlock';
 import TitleBlockTool from '@/components/editor/customBlocks/TitleBlock';
 import Delimiter from '@editorjs/delimiter';
 import Header from '@editorjs/header';
 import Image from '@editorjs/image';
-import List from '@editorjs/list';
 import Paragraph from '@editorjs/paragraph';
 import Quote from '@editorjs/quote';
 import Table from '@editorjs/table';
@@ -31,6 +31,12 @@ export const editorConfig: EditorConfig = {
       class: CustomList,
       config: {
         defaultStyle: 'unordered',
+      },
+    },
+    mention: {
+      class: MentionUserTool,
+      config: {
+        holderId: 'editorjs',
       },
     },
     image: {

--- a/apps/the_monkeys/src/config/editor/monkeys_editor_readonly.config.ts
+++ b/apps/the_monkeys/src/config/editor/monkeys_editor_readonly.config.ts
@@ -35,9 +35,6 @@ export const editorConfig: EditorConfig = {
     },
     mention: {
       class: MentionUserTool,
-      config: {
-        holderId: 'editorjs',
-      },
     },
     image: {
       class: Image,


### PR DESCRIPTION
### 📃 Why Merge This PR?

This PR introduces a fully custom "Mention" plugin for Editor.js. It allows users to type @ within the editor to trigger a dropdown, search for users, and seamlessly insert an UI mention pill (avatar + full name) directly into the paragraph block.

### API Endpoints used

<!-- linear:table-colwidths:266,266,266 -->
| Action | Endpoint | Details |
| -- | -- | -- |
| **User Search** | `${baseUrl}/user/search?search_term={query}&limit=5&offset=0` | Triggered as the user types after the `@` symbol. |
| **Fetch Profile Image Metadata** | `${baseUrl}/api/v2/storage/profiles/{username}/profile/meta` | Fetches the user's avatar metadata. |

### Performance Optimizations

* Network Debouncing & Local Caching: The fetchUsersDebounced method ensures we do not spam the search API on every keystroke. Additionally, a local queryCache prevents redundant network calls if the user backspaces and types the same query again.
* Missing Image Fallbacks (Preventing 404 status error): Before rendering images, the plugin fires a lightweight HEAD request to validate the profile image URL. If the image is missing or throws an error, it gracefully falls back to /default-profile.svg.

### 🛠️ Issue Fixed

Fixes the-monkeys/the_monkeys#555

### 🔍 PR Type

- [X] 💡 Feature
- [ ] 🐛 Bug Fix
- [ ] 📃 Documentation
- [ ] 🎨 UI Improvements
- [ ] 💻 Code Refactor
- [ ] ✅ Tests

### Attachments

<img src="https://github.com/user-attachments/assets/73541d2e-7f9b-4866-a3bf-626c10f44d08 " alt="Screenshot 2026-07-20 at 8 31 47 AM" width="897" data-linear-height="639" />