### PR TITLE
refractor: optimistically update follow button without waiting for ap…

### DIFF
--- a/apps/the_monkeys/src/components/user/buttons/followButton.tsx
+++ b/apps/the_monkeys/src/components/user/buttons/followButton.tsx
@@ -1,18 +1,108 @@
-import { useState } from 'react';
-
 import Icon from '@/components/icon';
-import { Loader } from '@/components/loader';
 import {
   CONNECTION_COUNT_QUERY_KEY,
   IS_FOLLOWING_USER_QUERY_KEY,
   useIsFollowingUser,
 } from '@/hooks/user/useUserConnections';
 import axiosInstance from '@/services/api/axiosInstance';
-import { useQueryClient } from '@tanstack/react-query';
+import { IsFollowedResponse } from '@/services/profile/userApiTypes';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@the-monkeys/ui/atoms/button';
 import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
 import { toast } from '@the-monkeys/ui/hooks/use-toast';
 import { twMerge } from 'tailwind-merge';
+
+// Shape of the follower-count cache data.
+// Adjust `count` field name if your actual API response uses a different key.
+interface ConnectionCountResponse {
+  status?: string;
+  count: number;
+}
+
+const useFollowMutation = (username?: string) => {
+  const queryClient = useQueryClient();
+
+  // Exact query keys used everywhere in this hook.
+  const followingKey = [IS_FOLLOWING_USER_QUERY_KEY, username];
+  const countKey = [CONNECTION_COUNT_QUERY_KEY, username];
+
+  return useMutation({
+    // Calls the follow or unfollow API based on the button clicked.
+    mutationFn: (nextIsFollowing: boolean) =>
+      axiosInstance.post(
+        `/user/${nextIsFollowing ? 'follow' : 'unfollow'}/${username}`
+      ),
+
+    // Runs immediately when mutate() is called — before the API responds.
+    onMutate: async (nextIsFollowing: boolean) => {
+      // Snapshot current values FIRST (before cancelling), so we have
+      // something to roll back to if the request fails.
+      const previousFollowStatus =
+        queryClient.getQueryData<IsFollowedResponse>(followingKey);
+      const previousCount =
+        queryClient.getQueryData<ConnectionCountResponse>(countKey);
+
+      // Update the UI immediately — this is NOT awaited, so the button
+      // and count change instantly, even on the very first click when
+      // an initial fetch might still be in flight.
+      queryClient.setQueryData<IsFollowedResponse>(followingKey, {
+        status: previousFollowStatus?.status ?? 'ok',
+        isFollowing: nextIsFollowing,
+      });
+
+      // Only bump the count if we have a valid number to start from —
+      // avoids briefly flashing 0 if the cache was empty/loading.
+      if (previousCount && typeof previousCount.count === 'number') {
+        queryClient.setQueryData<ConnectionCountResponse>(countKey, {
+          ...previousCount,
+          count: previousCount.count + (nextIsFollowing ? 1 : -1),
+        });
+      }
+
+      // Cancel any in-flight fetches in the background so they don't
+      // later overwrite our optimistic values. Intentionally NOT awaited
+      // here — awaiting this before the setQueryData calls above caused
+      // the first-click lag, since cancellation can take a moment to
+      // resolve when a fetch is freshly in flight.
+      queryClient.cancelQueries({ queryKey: followingKey });
+      queryClient.cancelQueries({ queryKey: countKey });
+
+      // Passed into onError as `context` so we can roll back.
+      return { previousFollowStatus, previousCount };
+    },
+
+    // Runs if the API call fails — undo everything onMutate changed.
+    onError: (err: unknown, _nextIsFollowing, context) => {
+      if (context?.previousFollowStatus) {
+        queryClient.setQueryData(followingKey, context.previousFollowStatus);
+      }
+      if (context?.previousCount) {
+        queryClient.setQueryData(countKey, context.previousCount);
+      }
+
+      toast({
+        variant: 'error',
+        title: 'Error',
+        description:
+          err instanceof Error ? err.message : 'Something went wrong.',
+      });
+    },
+
+    // Runs after success OR failure — refetch from server to stay in sync.
+    // `refetchType: 'active'` keeps the last known value visible on screen
+    // while refetching, instead of blanking out to 0/undefined.
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: followingKey,
+        refetchType: 'active',
+      });
+      queryClient.invalidateQueries({
+        queryKey: countKey,
+        refetchType: 'active',
+      });
+    },
+  });
+};
 
 export const FollowButton = ({
   username,
@@ -21,102 +111,34 @@ export const FollowButton = ({
   username?: string;
   className?: string;
 }) => {
-  const queryClient = useQueryClient();
-  const { followStatus, isLoading, isError } = useIsFollowingUser(username);
+  const { followStatus } = useIsFollowingUser(username);
+  const { mutate, isPending } = useFollowMutation(username);
 
-  const [loading, setLoading] = useState<boolean>(false);
-
-  // if (isLoading) return <Skeleton className='h-9 w-32 rounded-full' />;
-
-  // if (isError) return null;
-
-  const onUserFollow = async () => {
-    setLoading(true);
-
-    try {
-      const response = await axiosInstance.post(`/user/follow/${username}`);
-
-      if (response.status === 200) {
-        queryClient.invalidateQueries({
-          queryKey: [IS_FOLLOWING_USER_QUERY_KEY, username],
-        });
-        queryClient.invalidateQueries({
-          queryKey: [CONNECTION_COUNT_QUERY_KEY, username],
-        });
-      }
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        toast({
-          variant: 'error',
-          title: 'Error',
-          description: err.message || 'Failed to follow user.',
-        });
-      } else {
-        toast({
-          variant: 'error',
-          title: 'Error',
-          description: 'An unknown error occurred.',
-        });
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const onUserUnfollow = async () => {
-    setLoading(true);
-
-    try {
-      const response = await axiosInstance.post(`/user/unfollow/${username}`);
-
-      if (response.status === 200) {
-        queryClient.invalidateQueries({
-          queryKey: [IS_FOLLOWING_USER_QUERY_KEY, username],
-        });
-        queryClient.invalidateQueries({
-          queryKey: [CONNECTION_COUNT_QUERY_KEY, username],
-        });
-      }
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        toast({
-          variant: 'error',
-          title: 'Error',
-          description: err.message || 'Failed to unfollow user.',
-        });
-      } else {
-        toast({
-          variant: 'error',
-          title: 'Error',
-          description: 'An unknown error occurred.',
-        });
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
+  const isFollowing = !!followStatus?.isFollowing;
 
   return (
     <>
-      {followStatus?.isFollowing ? (
+      {isFollowing ? (
         <Button
           variant='secondary'
-          disabled={loading}
-          onClick={onUserUnfollow}
+          disabled={isPending}
+          onClick={() => mutate(false)}
           className={twMerge(className, '!text-base rounded-full')}
         >
-          {loading && <Loader />}
+          {/* Loader removed: text switches instantly via the optimistic
+              update, so showing a spinner here made it feel laggy even
+              though the state had already changed. `disabled` still
+              silently blocks double-clicks while the request is in flight. */}
           Unfollow
         </Button>
       ) : (
         <Button
           variant={'outline'}
           size={'sm'}
-          disabled={loading}
-          onClick={onUserFollow}
+          disabled={isPending}
+          onClick={() => mutate(true)}
           className={twMerge(className, '!text-base rounded-full')}
         >
-          {loading && <Loader />}
           Follow
         </Button>
       )}
@@ -131,101 +153,37 @@ export const FollowButtonIcon = ({
   username?: string;
   className?: string;
 }) => {
-  const queryClient = useQueryClient();
   const { followStatus, isLoading, isError } = useIsFollowingUser(username);
-
-  const [loading, setLoading] = useState<boolean>(false);
+  const { mutate, isPending } = useFollowMutation(username);
 
   if (isLoading) return <Skeleton className='size-9 rounded-full' />;
 
   if (isError) return null;
 
-  const onUserFollow = async () => {
-    setLoading(true);
-
-    try {
-      const response = await axiosInstance.post(`/user/follow/${username}`);
-
-      if (response.status === 200) {
-        queryClient.invalidateQueries({
-          queryKey: [IS_FOLLOWING_USER_QUERY_KEY, username],
-        });
-        queryClient.invalidateQueries({
-          queryKey: [CONNECTION_COUNT_QUERY_KEY, username],
-        });
-      }
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        toast({
-          variant: 'error',
-          title: 'Error',
-          description: err.message || 'Failed to follow user.',
-        });
-      } else {
-        toast({
-          variant: 'error',
-          title: 'Error',
-          description: 'An unknown error occurred.',
-        });
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const onUserUnfollow = async () => {
-    setLoading(true);
-
-    try {
-      const response = await axiosInstance.post(`/user/unfollow/${username}`);
-
-      if (response.status === 200) {
-        queryClient.invalidateQueries({
-          queryKey: [IS_FOLLOWING_USER_QUERY_KEY, username],
-        });
-        queryClient.invalidateQueries({
-          queryKey: [CONNECTION_COUNT_QUERY_KEY, username],
-        });
-      }
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        toast({
-          variant: 'error',
-          title: 'Error',
-          description: err.message || 'Failed to unfollow user.',
-        });
-      } else {
-        toast({
-          variant: 'error',
-          title: 'Error',
-          description: 'An unknown error occurred.',
-        });
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
+  const isFollowing = !!followStatus?.isFollowing;
 
   return (
     <>
-      {followStatus?.isFollowing ? (
+      {isFollowing ? (
         <Button
           variant='secondary'
           size='icon'
-          disabled={loading}
-          onClick={onUserUnfollow}
+          disabled={isPending}
+          onClick={() => mutate(false)}
           className={twMerge(className, 'rounded-full')}
         >
-          {loading ? <Loader /> : <Icon name='RiUserUnfollow' size={18} />}
+          {/* Icon renders immediately instead of swapping with a spinner,
+              so the icon change feels instant on click. */}
+          <Icon name='RiUserUnfollow' size={18} />
         </Button>
       ) : (
         <Button
           size='icon'
-          disabled={loading}
-          onClick={onUserFollow}
+          disabled={isPending}
+          onClick={() => mutate(true)}
           className={twMerge(className, 'rounded-full')}
         >
-          {loading ? <Loader /> : <Icon name='RiUserFollow' size={18} />}
+          <Icon name='RiUserFollow' size={18} />
         </Button>
       )}
     </>

--- a/apps/the_monkeys/src/components/user/buttons/followButton.tsx
+++ b/apps/the_monkeys/src/components/user/buttons/followButton.tsx
@@ -12,46 +12,38 @@ import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
 import { toast } from '@the-monkeys/ui/hooks/use-toast';
 import { twMerge } from 'tailwind-merge';
 
-// Shape of the follower-count cache data.
-// Adjust `count` field name if your actual API response uses a different key.
-interface ConnectionCountResponse {
+type ConnectionCountResponse = {
   status?: string;
   count: number;
-}
+};
+
+const followUnfollowUser = (username: string, nextIsFollowing: boolean) => {
+  return axiosInstance.post(
+    `/user/${nextIsFollowing ? 'follow' : 'unfollow'}/${username}`
+  );
+};
 
 const useFollowMutation = (username?: string) => {
   const queryClient = useQueryClient();
 
-  // Exact query keys used everywhere in this hook.
   const followingKey = [IS_FOLLOWING_USER_QUERY_KEY, username];
   const countKey = [CONNECTION_COUNT_QUERY_KEY, username];
 
   return useMutation({
-    // Calls the follow or unfollow API based on the button clicked.
     mutationFn: (nextIsFollowing: boolean) =>
-      axiosInstance.post(
-        `/user/${nextIsFollowing ? 'follow' : 'unfollow'}/${username}`
-      ),
+      followUnfollowUser(username!, nextIsFollowing),
 
-    // Runs immediately when mutate() is called — before the API responds.
     onMutate: async (nextIsFollowing: boolean) => {
-      // Snapshot current values FIRST (before cancelling), so we have
-      // something to roll back to if the request fails.
       const previousFollowStatus =
         queryClient.getQueryData<IsFollowedResponse>(followingKey);
       const previousCount =
         queryClient.getQueryData<ConnectionCountResponse>(countKey);
 
-      // Update the UI immediately — this is NOT awaited, so the button
-      // and count change instantly, even on the very first click when
-      // an initial fetch might still be in flight.
       queryClient.setQueryData<IsFollowedResponse>(followingKey, {
         status: previousFollowStatus?.status ?? 'ok',
         isFollowing: nextIsFollowing,
       });
 
-      // Only bump the count if we have a valid number to start from —
-      // avoids briefly flashing 0 if the cache was empty/loading.
       if (previousCount && typeof previousCount.count === 'number') {
         queryClient.setQueryData<ConnectionCountResponse>(countKey, {
           ...previousCount,
@@ -59,19 +51,12 @@ const useFollowMutation = (username?: string) => {
         });
       }
 
-      // Cancel any in-flight fetches in the background so they don't
-      // later overwrite our optimistic values. Intentionally NOT awaited
-      // here — awaiting this before the setQueryData calls above caused
-      // the first-click lag, since cancellation can take a moment to
-      // resolve when a fetch is freshly in flight.
       queryClient.cancelQueries({ queryKey: followingKey });
       queryClient.cancelQueries({ queryKey: countKey });
 
-      // Passed into onError as `context` so we can roll back.
       return { previousFollowStatus, previousCount };
     },
 
-    // Runs if the API call fails — undo everything onMutate changed.
     onError: (err: unknown, _nextIsFollowing, context) => {
       if (context?.previousFollowStatus) {
         queryClient.setQueryData(followingKey, context.previousFollowStatus);
@@ -88,9 +73,6 @@ const useFollowMutation = (username?: string) => {
       });
     },
 
-    // Runs after success OR failure — refetch from server to stay in sync.
-    // `refetchType: 'active'` keeps the last known value visible on screen
-    // while refetching, instead of blanking out to 0/undefined.
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: followingKey,
@@ -116,19 +98,18 @@ export const FollowButton = ({
 
   const isFollowing = !!followStatus?.isFollowing;
 
+  const handleFollow = () => mutate(true);
+  const handleUnfollow = () => mutate(false);
+
   return (
     <>
       {isFollowing ? (
         <Button
           variant='secondary'
           disabled={isPending}
-          onClick={() => mutate(false)}
+          onClick={handleUnfollow}
           className={twMerge(className, '!text-base rounded-full')}
         >
-          {/* Loader removed: text switches instantly via the optimistic
-              update, so showing a spinner here made it feel laggy even
-              though the state had already changed. `disabled` still
-              silently blocks double-clicks while the request is in flight. */}
           Unfollow
         </Button>
       ) : (
@@ -136,7 +117,7 @@ export const FollowButton = ({
           variant={'outline'}
           size={'sm'}
           disabled={isPending}
-          onClick={() => mutate(true)}
+          onClick={handleFollow}
           className={twMerge(className, '!text-base rounded-full')}
         >
           Follow
@@ -162,6 +143,9 @@ export const FollowButtonIcon = ({
 
   const isFollowing = !!followStatus?.isFollowing;
 
+  const handleFollow = () => mutate(true);
+  const handleUnfollow = () => mutate(false);
+
   return (
     <>
       {isFollowing ? (
@@ -169,18 +153,16 @@ export const FollowButtonIcon = ({
           variant='secondary'
           size='icon'
           disabled={isPending}
-          onClick={() => mutate(false)}
+          onClick={handleUnfollow}
           className={twMerge(className, 'rounded-full')}
         >
-          {/* Icon renders immediately instead of swapping with a spinner,
-              so the icon change feels instant on click. */}
           <Icon name='RiUserUnfollow' size={18} />
         </Button>
       ) : (
         <Button
           size='icon'
           disabled={isPending}
-          onClick={() => mutate(true)}
+          onClick={handleFollow}
           className={twMerge(className, 'rounded-full')}
         >
           <Icon name='RiUserFollow' size={18} />

--- a/apps/the_monkeys/src/components/user/buttons/followButton.tsx
+++ b/apps/the_monkeys/src/components/user/buttons/followButton.tsx
@@ -5,17 +5,15 @@ import {
   useIsFollowingUser,
 } from '@/hooks/user/useUserConnections';
 import axiosInstance from '@/services/api/axiosInstance';
-import { IsFollowedResponse } from '@/services/profile/userApiTypes';
+import {
+  ConnectionCountResponse,
+  IsFollowedResponse,
+} from '@/services/profile/userApiTypes';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@the-monkeys/ui/atoms/button';
 import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
 import { toast } from '@the-monkeys/ui/hooks/use-toast';
 import { twMerge } from 'tailwind-merge';
-
-type ConnectionCountResponse = {
-  status?: string;
-  count: number;
-};
 
 const followUnfollowUser = (username: string, nextIsFollowing: boolean) => {
   return axiosInstance.post(
@@ -44,10 +42,10 @@ const useFollowMutation = (username?: string) => {
         isFollowing: nextIsFollowing,
       });
 
-      if (previousCount && typeof previousCount.count === 'number') {
+      if (previousCount && typeof previousCount.followers === 'number') {
         queryClient.setQueryData<ConnectionCountResponse>(countKey, {
           ...previousCount,
-          count: previousCount.count + (nextIsFollowing ? 1 : -1),
+          followers: previousCount.followers + (nextIsFollowing ? 1 : -1),
         });
       }
 

--- a/apps/the_monkeys/src/components/user/buttons/followButton.tsx
+++ b/apps/the_monkeys/src/components/user/buttons/followButton.tsx
@@ -15,10 +15,12 @@ import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
 import { toast } from '@the-monkeys/ui/hooks/use-toast';
 import { twMerge } from 'tailwind-merge';
 
-const followUnfollowUser = (username: string, nextIsFollowing: boolean) => {
-  return axiosInstance.post(
-    `/user/${nextIsFollowing ? 'follow' : 'unfollow'}/${username}`
-  );
+const followUser = (username: string) => {
+  return axiosInstance.post(`/user/follow/${username}`);
+};
+
+const unfollowUser = (username: string) => {
+  return axiosInstance.post(`/user/unfollow/${username}`);
 };
 
 const useFollowMutation = (username?: string) => {
@@ -29,7 +31,7 @@ const useFollowMutation = (username?: string) => {
 
   return useMutation({
     mutationFn: (nextIsFollowing: boolean) =>
-      followUnfollowUser(username!, nextIsFollowing),
+      nextIsFollowing ? followUser(username!) : unfollowUser(username!),
 
     onMutate: async (nextIsFollowing: boolean) => {
       const previousFollowStatus =
@@ -42,7 +44,7 @@ const useFollowMutation = (username?: string) => {
         isFollowing: nextIsFollowing,
       });
 
-      if (previousCount && typeof previousCount.followers === 'number') {
+      if (previousCount) {
         queryClient.setQueryData<ConnectionCountResponse>(countKey, {
           ...previousCount,
           followers: previousCount.followers + (nextIsFollowing ? 1 : -1),

--- a/apps/the_monkeys/src/components/user/buttons/followButton.tsx
+++ b/apps/the_monkeys/src/components/user/buttons/followButton.tsx
@@ -23,17 +23,25 @@ const unfollowUser = (username: string) => {
   return axiosInstance.post(`/user/unfollow/${username}`);
 };
 
-const useFollowMutation = (username?: string) => {
+type FollowMutationVariables = {
+  username: string;
+  nextIsFollowing: boolean;
+};
+
+const useFollowMutation = () => {
   const queryClient = useQueryClient();
 
-  const followingKey = [IS_FOLLOWING_USER_QUERY_KEY, username];
-  const countKey = [CONNECTION_COUNT_QUERY_KEY, username];
-
   return useMutation({
-    mutationFn: (nextIsFollowing: boolean) =>
-      nextIsFollowing ? followUser(username!) : unfollowUser(username!),
+    mutationFn: ({ username, nextIsFollowing }: FollowMutationVariables) =>
+      nextIsFollowing ? followUser(username) : unfollowUser(username),
 
-    onMutate: async (nextIsFollowing: boolean) => {
+    onMutate: async ({
+      username,
+      nextIsFollowing,
+    }: FollowMutationVariables) => {
+      const followingKey = [IS_FOLLOWING_USER_QUERY_KEY, username];
+      const countKey = [CONNECTION_COUNT_QUERY_KEY, username];
+
       const previousFollowStatus =
         queryClient.getQueryData<IsFollowedResponse>(followingKey);
       const previousCount =
@@ -54,15 +62,18 @@ const useFollowMutation = (username?: string) => {
       queryClient.cancelQueries({ queryKey: followingKey });
       queryClient.cancelQueries({ queryKey: countKey });
 
-      return { previousFollowStatus, previousCount };
+      return { previousFollowStatus, previousCount, followingKey, countKey };
     },
 
-    onError: (err: unknown, _nextIsFollowing, context) => {
+    onError: (err: unknown, _variables, context) => {
       if (context?.previousFollowStatus) {
-        queryClient.setQueryData(followingKey, context.previousFollowStatus);
+        queryClient.setQueryData(
+          context.followingKey,
+          context.previousFollowStatus
+        );
       }
       if (context?.previousCount) {
-        queryClient.setQueryData(countKey, context.previousCount);
+        queryClient.setQueryData(context.countKey, context.previousCount);
       }
 
       toast({
@@ -73,13 +84,15 @@ const useFollowMutation = (username?: string) => {
       });
     },
 
-    onSettled: () => {
+    onSettled: (_data, _error, _variables, context) => {
+      if (!context) return;
+
       queryClient.invalidateQueries({
-        queryKey: followingKey,
+        queryKey: context.followingKey,
         refetchType: 'active',
       });
       queryClient.invalidateQueries({
-        queryKey: countKey,
+        queryKey: context.countKey,
         refetchType: 'active',
       });
     },
@@ -94,12 +107,19 @@ export const FollowButton = ({
   className?: string;
 }) => {
   const { followStatus } = useIsFollowingUser(username);
-  const { mutate, isPending } = useFollowMutation(username);
+  const { mutate, isPending } = useFollowMutation();
 
   const isFollowing = !!followStatus?.isFollowing;
 
-  const handleFollow = () => mutate(true);
-  const handleUnfollow = () => mutate(false);
+  const handleFollow = () => {
+    if (!username) return;
+    mutate({ username, nextIsFollowing: true });
+  };
+
+  const handleUnfollow = () => {
+    if (!username) return;
+    mutate({ username, nextIsFollowing: false });
+  };
 
   return (
     <>
@@ -135,7 +155,7 @@ export const FollowButtonIcon = ({
   className?: string;
 }) => {
   const { followStatus, isLoading, isError } = useIsFollowingUser(username);
-  const { mutate, isPending } = useFollowMutation(username);
+  const { mutate, isPending } = useFollowMutation();
 
   if (isLoading) return <Skeleton className='size-9 rounded-full' />;
 
@@ -143,8 +163,15 @@ export const FollowButtonIcon = ({
 
   const isFollowing = !!followStatus?.isFollowing;
 
-  const handleFollow = () => mutate(true);
-  const handleUnfollow = () => mutate(false);
+  const handleFollow = () => {
+    if (!username) return;
+    mutate({ username, nextIsFollowing: true });
+  };
+
+  const handleUnfollow = () => {
+    if (!username) return;
+    mutate({ username, nextIsFollowing: false });
+  };
 
   return (
     <>


### PR DESCRIPTION
## 📃 Why Merge This PR?

This PR implements optimistic UI updates for the Follow/Unfollow button to provide a faster and more responsive user experience.

Previously, the follow state and follower count were updated only after the API request completed. With this change, both are updated immediately on user interaction, while maintaining consistency by rolling back the UI if the API request fails.

---

## 🛠️ Issue Fixed

Fixes the-monkeys/the_monkeys#565

---

## 🔍 Changes

* Added optimistic updates for follow and unfollow actions.
* Updated the follow state immediately on button click.
* Updated the follower count optimistically without waiting for the API response.
* Added rollback logic to restore the previous state if the API request fails.

---

## ✅ Testing

* Verified the follow state updates immediately on click.
* Verified the unfollow state updates immediately on click.
* Verified the follower count updates optimistically.
* Verified the UI correctly rolls back when the API request fails.

---

## 🔍 PR Type

- [X] 💡 Feature
- [X] 🎨 UI Improvements