### PR TITLE
Feat/prettier cache

### DIFF
--- a/apps/the_monkeys/package.json
+++ b/apps/the_monkeys/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write ."
+    "format": "prettier --cache --write ."
   },
   "dependencies": {
     "@editorjs/delimiter": "1.4.2",


### PR DESCRIPTION
### 📃 Why Merge This PR?

This PR enables Prettier's built-in cache by updating the format script to use `--cache`. This improves formatting performance by skipping unchanged files on subsequent runs while preserving the existing formatting behavior.

### 🛠️ Issue Fixed

Fixes the-monkeys/the_monkeys#578

### 🔍 PR Type

- [ ] 💡 Feature
- [ ] 🐛 Bug Fix
- [ ] 📃 Documentation
- [ ] 🎨 UI Improvements
- [X] 💻 Code Refactor
- [ ] ✅ Tests