### PR TITLE
fix: update profile image hook usage in delete profile dialog

### DIFF
--- a/apps/the_monkeys/src/app/[username]/components/profile/UpdateDialog.tsx
+++ b/apps/the_monkeys/src/app/[username]/components/profile/UpdateDialog.tsx
@@ -52,7 +52,6 @@ export const UpdateDialog = ({ data }: { data: IUser }) => {
   const { imageUrl } = useProfileImage(data.username);
   const [loading, setLoading] = useState<boolean>(false);
   const [open, setOpen] = useState<boolean>(false);
-
   const hasProfileImage = imageUrl !== '';
 
   const form = useForm<z.infer<typeof updateProfileSchema>>({

--- a/apps/the_monkeys/src/app/[username]/components/profile/UpdateDialog.tsx
+++ b/apps/the_monkeys/src/app/[username]/components/profile/UpdateDialog.tsx
@@ -49,15 +49,11 @@ export const UpdateDialog = ({ data }: { data: IUser }) => {
     isLoading,
     isError,
   } = useGetAuthUserProfile(data.username);
-  const {
-    imageUrl,
-    isLoading: imageLoading,
-    isError: imageError,
-  } = useProfileImage(data.username);
+  const { imageUrl } = useProfileImage(data.username);
   const [loading, setLoading] = useState<boolean>(false);
   const [open, setOpen] = useState<boolean>(false);
 
-  const hasProfileImage = !imageLoading && !imageError && imageUrl !== '';
+  const hasProfileImage = imageUrl !== '';
 
   const form = useForm<z.infer<typeof updateProfileSchema>>({
     resolver: zodResolver(updateProfileSchema),

--- a/apps/the_monkeys/src/app/[username]/components/profile/UpdateDialog.tsx
+++ b/apps/the_monkeys/src/app/[username]/components/profile/UpdateDialog.tsx
@@ -7,6 +7,7 @@ import ProfileImage, { ProfileFrame } from '@/components/profileImage';
 import { UpdateDetailsFormSkeleton } from '@/components/skeletons/formSkeleton';
 import { DeleteProfileDialog } from '@/components/user/dialogs/deleteProfileDialog';
 import { UpdateProfileDialog } from '@/components/user/dialogs/updateProfileDialog';
+import useProfileImage from '@/hooks/profile/useProfileImage';
 import useGetAuthUserProfile from '@/hooks/user/useGetAuthUserProfile';
 import { USER_QUERY_KEY } from '@/hooks/user/useUser';
 import axiosInstance from '@/services/api/axiosInstance';
@@ -48,8 +49,15 @@ export const UpdateDialog = ({ data }: { data: IUser }) => {
     isLoading,
     isError,
   } = useGetAuthUserProfile(data.username);
+  const {
+    imageUrl,
+    isLoading: imageLoading,
+    isError: imageError,
+  } = useProfileImage(data.username);
   const [loading, setLoading] = useState<boolean>(false);
   const [open, setOpen] = useState<boolean>(false);
+
+  const hasProfileImage = !imageLoading && !imageError && imageUrl !== '';
 
   const form = useForm<z.infer<typeof updateProfileSchema>>({
     resolver: zodResolver(updateProfileSchema),
@@ -141,7 +149,7 @@ export const UpdateDialog = ({ data }: { data: IUser }) => {
                 </ProfileFrame>
 
                 <div className='space-x-2'>
-                  <DeleteProfileDialog />
+                  {hasProfileImage && <DeleteProfileDialog />}
 
                   <UpdateProfileDialog />
                 </div>

--- a/apps/the_monkeys/src/app/settings/components/Profile.tsx
+++ b/apps/the_monkeys/src/app/settings/components/Profile.tsx
@@ -36,10 +36,10 @@ import { parseDateTime } from './profile/parseDate';
 
 export const Profile = ({ data }: { data?: IUser }) => {
   const { data: user } = useGetAuthUserProfile(data?.username);
-  const { imageUrl, isLoading, isError } = useProfileImage(data?.username);
+  const { imageUrl } = useProfileImage(data?.username);
   const [loading, setLoading] = useState<boolean>(false);
 
-  const hasProfileImage = !isLoading && !isError && imageUrl !== '';
+  const hasProfileImage = imageUrl !== '';
 
   const form = useForm<z.infer<typeof updateProfileSchema>>({
     resolver: zodResolver(updateProfileSchema),

--- a/apps/the_monkeys/src/app/settings/components/Profile.tsx
+++ b/apps/the_monkeys/src/app/settings/components/Profile.tsx
@@ -38,7 +38,6 @@ export const Profile = ({ data }: { data?: IUser }) => {
   const { data: user } = useGetAuthUserProfile(data?.username);
   const { imageUrl } = useProfileImage(data?.username);
   const [loading, setLoading] = useState<boolean>(false);
-
   const hasProfileImage = imageUrl !== '';
 
   const form = useForm<z.infer<typeof updateProfileSchema>>({

--- a/apps/the_monkeys/src/app/settings/components/Profile.tsx
+++ b/apps/the_monkeys/src/app/settings/components/Profile.tsx
@@ -4,6 +4,7 @@ import { Loader } from '@/components/loader';
 import ProfileImage, { ProfileFrame } from '@/components/profileImage';
 import { DeleteProfileDialog } from '@/components/user/dialogs/deleteProfileDialog';
 import { UpdateProfileDialog } from '@/components/user/dialogs/updateProfileDialog';
+import useProfileImage from '@/hooks/profile/useProfileImage';
 import useGetAuthUserProfile from '@/hooks/user/useGetAuthUserProfile';
 import { updateProfileSchema } from '@/lib/schema/settings';
 import axiosInstance from '@/services/api/axiosInstance';
@@ -35,7 +36,10 @@ import { parseDateTime } from './profile/parseDate';
 
 export const Profile = ({ data }: { data?: IUser }) => {
   const { data: user } = useGetAuthUserProfile(data?.username);
+  const { imageUrl, isLoading, isError } = useProfileImage(data?.username);
   const [loading, setLoading] = useState<boolean>(false);
+
+  const hasProfileImage = !isLoading && !isError && imageUrl !== '';
 
   const form = useForm<z.infer<typeof updateProfileSchema>>({
     resolver: zodResolver(updateProfileSchema),
@@ -110,7 +114,7 @@ export const Profile = ({ data }: { data?: IUser }) => {
               </ProfileFrame>
 
               <div className='space-x-2'>
-                <DeleteProfileDialog />
+                {hasProfileImage && <DeleteProfileDialog />}
 
                 <UpdateProfileDialog />
               </div>

--- a/apps/the_monkeys/src/components/user/dialogs/deleteProfileDialog.tsx
+++ b/apps/the_monkeys/src/components/user/dialogs/deleteProfileDialog.tsx
@@ -5,7 +5,9 @@ import { useState } from 'react';
 import Icon from '@/components/icon';
 import { Loader } from '@/components/loader';
 import useAuth from '@/hooks/auth/useAuth';
-import useProfileImage, { PROFILE_IMAGE_QUERY_KEY,} from '@/hooks/profile/useProfileImage';
+import useProfileImage, {
+  PROFILE_IMAGE_QUERY_KEY,
+} from '@/hooks/profile/useProfileImage';
 import axiosInstanceV2 from '@/services/api/axiosInstanceV2';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@the-monkeys/ui/atoms/button';

--- a/apps/the_monkeys/src/components/user/dialogs/deleteProfileDialog.tsx
+++ b/apps/the_monkeys/src/components/user/dialogs/deleteProfileDialog.tsx
@@ -21,6 +21,7 @@ import { toast } from '@the-monkeys/ui/hooks/use-toast';
 export const DeleteProfileDialog = () => {
   const queryClient = useQueryClient();
   const { data } = useAuth();
+
   const [open, setOpen] = useState<boolean>();
   const [loading, setLoading] = useState<boolean>(false);
 

--- a/apps/the_monkeys/src/components/user/dialogs/deleteProfileDialog.tsx
+++ b/apps/the_monkeys/src/components/user/dialogs/deleteProfileDialog.tsx
@@ -5,9 +5,7 @@ import { useState } from 'react';
 import Icon from '@/components/icon';
 import { Loader } from '@/components/loader';
 import useAuth from '@/hooks/auth/useAuth';
-import useProfileImage, {
-  PROFILE_IMAGE_QUERY_KEY,
-} from '@/hooks/profile/useProfileImage';
+import { PROFILE_IMAGE_QUERY_KEY } from '@/hooks/profile/useProfileImage';
 import axiosInstanceV2 from '@/services/api/axiosInstanceV2';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@the-monkeys/ui/atoms/button';
@@ -23,7 +21,6 @@ import { toast } from '@the-monkeys/ui/hooks/use-toast';
 export const DeleteProfileDialog = () => {
   const queryClient = useQueryClient();
   const { data } = useAuth();
-  const { imageUrl, isLoading, isError } = useProfileImage(data?.username);
   const [open, setOpen] = useState<boolean>();
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -72,7 +69,6 @@ export const DeleteProfileDialog = () => {
     }
   };
 
-  if (isLoading || isError || imageUrl === '') return null;
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>

--- a/apps/the_monkeys/src/components/user/dialogs/deleteProfileDialog.tsx
+++ b/apps/the_monkeys/src/components/user/dialogs/deleteProfileDialog.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import Icon from '@/components/icon';
 import { Loader } from '@/components/loader';
 import useAuth from '@/hooks/auth/useAuth';
-import { PROFILE_IMAGE_QUERY_KEY } from '@/hooks/profile/useProfileImage';
+import useProfileImage, { PROFILE_IMAGE_QUERY_KEY,} from '@/hooks/profile/useProfileImage';
 import axiosInstanceV2 from '@/services/api/axiosInstanceV2';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@the-monkeys/ui/atoms/button';
@@ -21,7 +21,7 @@ import { toast } from '@the-monkeys/ui/hooks/use-toast';
 export const DeleteProfileDialog = () => {
   const queryClient = useQueryClient();
   const { data } = useAuth();
-
+  const { imageUrl, isLoading, isError } = useProfileImage(data?.username);
   const [open, setOpen] = useState<boolean>();
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -70,6 +70,7 @@ export const DeleteProfileDialog = () => {
     }
   };
 
+  if (isLoading || isError || imageUrl === '') return null;
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>


### PR DESCRIPTION
# 📃 Why Merge This PR?

This PR fixes a UI issue where the **Delete Profile Photo** button was shown even when the user had not uploaded a profile picture.

The button is now displayed **only when a custom profile picture exists**, resulting in a cleaner and more intuitive user experience.

---

# 🛠️ Issue Fixed

Fixes the-monkeys/the_monkeys#609

### Changes

* Added a simple conditional check using the existing `useProfileImage` hook.
* Show the **Delete** button only when an uploaded profile picture exists.
* Hide the button when the user is using the default profile picture.

---

# 🧪 Testing

Go to **Settings → Update Profile** and verify:

* ✅ Delete button is visible when a profile picture exists.
* ✅ Delete button is hidden when no profile picture exists.
* ✅ Uploading a picture shows the Delete button.
* ✅ Deleting the picture hides the Delete button.

---

# 🔍 PR Type

- [X] 🐛 Bug Fix
- [X] 🎨 UI Improvements  <br>< />< />