### PR TITLE
Migrate from editorjs to monkeys-editor

### DIFF
--- a/apps/the_monkeys/package.json
+++ b/apps/the_monkeys/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@editorjs/delimiter": "1.4.2",
-    "@editorjs/editorjs": "2.29.1",
     "@editorjs/header": "2.8.1",
     "@editorjs/image": "2.9.0",
     "@editorjs/paragraph": "2.11.4",
@@ -27,6 +26,7 @@
     "@remixicon/react": "^4.1.1",
     "@tanstack/react-query": "^5.66.3",
     "@the-monkeys/ui": "workspace:*",
+    "@themonkeys/monkeys-editor": "1.0.1",
     "axios": "^1.6.8",
     "bowser": "^2.11.0",
     "class-variance-authority": "^0.7.0",

--- a/apps/the_monkeys/src/app/edit/[blogId]/page.tsx
+++ b/apps/the_monkeys/src/app/edit/[blogId]/page.tsx
@@ -16,9 +16,9 @@ import useGetDraftBlogDetail, {
 } from '@/hooks/blog/useGetDraftBlogDetail';
 import axiosInstance from '@/services/api/axiosInstance';
 import axiosInstanceV2 from '@/services/api/axiosInstanceV2';
-import { OutputData } from '@editorjs/editorjs';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from '@the-monkeys/ui/hooks/use-toast';
+import { OutputData } from 'monkeys-editor';
 import { twMerge } from 'tailwind-merge';
 
 const Editor = dynamic(() => import('@/components/editor'), {
@@ -137,7 +137,7 @@ const EditPage = ({ params }: { params: { blogId: string } }) => {
       return {
         owner_account_id: accountId,
         author_list: [accountId],
-        content_type: 'editorjs',
+        content_type: 'monkeys_editor',
         blog: {
           time: data?.time || Date.now(),
           blocks:

--- a/apps/the_monkeys/src/app/edit/[blogId]/page.tsx
+++ b/apps/the_monkeys/src/app/edit/[blogId]/page.tsx
@@ -18,7 +18,7 @@ import axiosInstance from '@/services/api/axiosInstance';
 import axiosInstanceV2 from '@/services/api/axiosInstanceV2';
 import { useQueryClient } from '@tanstack/react-query';
 import { toast } from '@the-monkeys/ui/hooks/use-toast';
-import { OutputData } from 'monkeys-editor';
+import { OutputData } from '@themonkeys/monkeys-editor';
 import { twMerge } from 'tailwind-merge';
 
 const Editor = dynamic(() => import('@/components/editor'), {

--- a/apps/the_monkeys/src/app/globals.css
+++ b/apps/the_monkeys/src/app/globals.css
@@ -660,7 +660,7 @@ li.cdx-list__item {
   color: #121212;
 }
 
-#editorjs_editor-container {
+#monkeys_editor_editor-container {
   padding: 0;
 }
 

--- a/apps/the_monkeys/src/components/blog/actions/PublishBlogDialog.tsx
+++ b/apps/the_monkeys/src/components/blog/actions/PublishBlogDialog.tsx
@@ -4,7 +4,6 @@ import FormSearchSelect from '@/components/FormSearchSelect';
 import { Loader } from '@/components/loader';
 import { BLOG_TOPICS_MAX_COUNT } from '@/constants/topics';
 import useGetAllTopics from '@/hooks/user/useGetAllTopics';
-import { OutputData } from '@editorjs/editorjs';
 import { Button } from '@the-monkeys/ui/atoms/button';
 import {
   Dialog,
@@ -16,6 +15,7 @@ import {
 } from '@the-monkeys/ui/atoms/dialog';
 import { Label } from '@the-monkeys/ui/atoms/label';
 import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
+import { OutputData } from 'monkeys-editor';
 import { twMerge } from 'tailwind-merge';
 
 import { BlogDescription, BlogImage, BlogTitle } from '../getBlogContent';

--- a/apps/the_monkeys/src/components/blog/actions/PublishBlogDialog.tsx
+++ b/apps/the_monkeys/src/components/blog/actions/PublishBlogDialog.tsx
@@ -15,7 +15,7 @@ import {
 } from '@the-monkeys/ui/atoms/dialog';
 import { Label } from '@the-monkeys/ui/atoms/label';
 import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
-import { OutputData } from 'monkeys-editor';
+import { OutputData } from '@themonkeys/monkeys-editor';
 import { twMerge } from 'tailwind-merge';
 
 import { BlogDescription, BlogImage, BlogTitle } from '../getBlogContent';

--- a/apps/the_monkeys/src/components/blog/actions/PublishBlogDrawer.tsx
+++ b/apps/the_monkeys/src/components/blog/actions/PublishBlogDrawer.tsx
@@ -21,7 +21,7 @@ import { Label } from '@the-monkeys/ui/atoms/label';
 import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
 import { Switch } from '@the-monkeys/ui/atoms/switch';
 import { TextArea } from '@the-monkeys/ui/atoms/text-area';
-import { OutputData } from 'monkeys-editor';
+import { OutputData } from '@themonkeys/monkeys-editor';
 import { twMerge } from 'tailwind-merge';
 
 import ScheduleDateTimePicker from '../ScheduleDateTimePicker';

--- a/apps/the_monkeys/src/components/blog/actions/PublishBlogDrawer.tsx
+++ b/apps/the_monkeys/src/components/blog/actions/PublishBlogDrawer.tsx
@@ -6,7 +6,6 @@ import { Loader } from '@/components/loader';
 import { BLOG_TOPICS_MAX_COUNT } from '@/constants/topics';
 import { useScheduleState } from '@/hooks/blog/schedule/useScheduleState';
 import useGetAllTopics from '@/hooks/user/useGetAllTopics';
-import { OutputData } from '@editorjs/editorjs';
 import { Button } from '@the-monkeys/ui/atoms/button';
 import {
   Drawer,
@@ -22,6 +21,7 @@ import { Label } from '@the-monkeys/ui/atoms/label';
 import { Skeleton } from '@the-monkeys/ui/atoms/skeleton';
 import { Switch } from '@the-monkeys/ui/atoms/switch';
 import { TextArea } from '@the-monkeys/ui/atoms/text-area';
+import { OutputData } from 'monkeys-editor';
 import { twMerge } from 'tailwind-merge';
 
 import ScheduleDateTimePicker from '../ScheduleDateTimePicker';
@@ -41,7 +41,7 @@ const INVALID_IMAGE_EXTENSIONS = ['gif', 'apng'];
 
 /**
  * Extracts blog preview metadata (title, description, image) from
- * EditorJS output data.
+ * MonkeysEditor output data.
  */
 const extractBlogPreview = (data: OutputData | null) => {
   const title =

--- a/apps/the_monkeys/src/components/editor/customBlocks/CustomListBlock/index.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/CustomListBlock/index.ts
@@ -1,4 +1,4 @@
-import { API, BlockTool, ToolboxConfig } from 'monkeys-editor';
+import { API, BlockTool, ToolboxConfig } from '@themonkeys/monkeys-editor';
 
 import './style.css';
 import { ConstructorArgs, ListItemData, ListToolData } from './utils/interface';

--- a/apps/the_monkeys/src/components/editor/customBlocks/CustomListBlock/index.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/CustomListBlock/index.ts
@@ -1,4 +1,4 @@
-import { API, BlockTool, ToolboxConfig } from '@editorjs/editorjs';
+import { API, BlockTool, ToolboxConfig } from 'monkeys-editor';
 
 import './style.css';
 import { ConstructorArgs, ListItemData, ListToolData } from './utils/interface';

--- a/apps/the_monkeys/src/components/editor/customBlocks/CustomListBlock/utils/interface.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/CustomListBlock/utils/interface.ts
@@ -1,4 +1,4 @@
-import { API } from 'monkeys-editor';
+import { API } from '@themonkeys/monkeys-editor';
 
 export interface ConstructorArgs {
   api: API;

--- a/apps/the_monkeys/src/components/editor/customBlocks/CustomListBlock/utils/interface.ts
+++ b/apps/the_monkeys/src/components/editor/customBlocks/CustomListBlock/utils/interface.ts
@@ -1,4 +1,4 @@
-import { API } from '@editorjs/editorjs';
+import { API } from 'monkeys-editor';
 
 export interface ConstructorArgs {
   api: API;

--- a/apps/the_monkeys/src/components/editor/customBlocks/TitleBlock/index.tsx
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TitleBlock/index.tsx
@@ -1,4 +1,9 @@
-import { API, BlockTool, BlockToolData, ToolboxConfig } from 'monkeys-editor';
+import {
+  API,
+  BlockTool,
+  BlockToolData,
+  ToolboxConfig,
+} from '@themonkeys/monkeys-editor';
 
 import './styles/titleBlock.css';
 

--- a/apps/the_monkeys/src/components/editor/customBlocks/TitleBlock/index.tsx
+++ b/apps/the_monkeys/src/components/editor/customBlocks/TitleBlock/index.tsx
@@ -1,9 +1,4 @@
-import {
-  API,
-  BlockTool,
-  BlockToolData,
-  ToolboxConfig,
-} from '@editorjs/editorjs';
+import { API, BlockTool, BlockToolData, ToolboxConfig } from 'monkeys-editor';
 
 import './styles/titleBlock.css';
 

--- a/apps/the_monkeys/src/components/editor/index.tsx
+++ b/apps/the_monkeys/src/components/editor/index.tsx
@@ -4,7 +4,7 @@ import React, { FC, useEffect, useMemo, useRef } from 'react';
 
 import { getEditorConfig } from '@/config/editor/monkeys_editor.config';
 import axiosInstanceV2 from '@/services/api/axiosInstanceV2';
-import MonkeysEditor, { OutputData } from 'monkeys-editor';
+import MonkeysEditor, { OutputData } from '@themonkeys/monkeys-editor';
 
 export type EditorProps = {
   blogId: string;

--- a/apps/the_monkeys/src/components/editor/index.tsx
+++ b/apps/the_monkeys/src/components/editor/index.tsx
@@ -2,9 +2,9 @@
 
 import React, { FC, useEffect, useMemo, useRef } from 'react';
 
-import { getEditorConfig } from '@/config/editor/editorjs.config';
+import { getEditorConfig } from '@/config/editor/monkeys_editor.config';
 import axiosInstanceV2 from '@/services/api/axiosInstanceV2';
-import EditorJS, { OutputData } from '@editorjs/editorjs';
+import MonkeysEditor, { OutputData } from 'monkeys-editor';
 
 export type EditorProps = {
   blogId: string;
@@ -12,7 +12,7 @@ export type EditorProps = {
   onChange: (data: OutputData) => void;
 };
 
-// Extract all file URLs from EditorJS blocks that have data.file.url
+// Extract all file URLs from MonkeysEditor blocks that have data.file.url
 function extractFileUrls(blocks: OutputData['blocks']): Set<string> {
   const urls = new Set<string>();
   for (const block of blocks) {
@@ -39,7 +39,7 @@ const Editor: FC<EditorProps> = React.memo(function Editor({
   data,
   onChange,
 }) {
-  const editorInstance = useRef<EditorJS | null>(null);
+  const editorInstance = useRef<MonkeysEditor | null>(null);
   const prevFileUrls = useRef<Set<string>>(extractFileUrls(data?.blocks || []));
   const debounceTimer = useRef<NodeJS.Timeout | null>(null);
   const localDataRef = useRef<OutputData | null>(data);
@@ -49,7 +49,7 @@ const Editor: FC<EditorProps> = React.memo(function Editor({
 
   useEffect(() => {
     if (!editorInstance.current) {
-      editorInstance.current = new EditorJS({
+      editorInstance.current = new MonkeysEditor({
         ...editorConfig,
         data: data,
         onChange: (api) => {
@@ -105,7 +105,10 @@ const Editor: FC<EditorProps> = React.memo(function Editor({
   }, [data]);
 
   return (
-    <div className='w-full px-4 space-y-6' id='editorjs_editor-container'></div>
+    <div
+      className='w-full px-4 space-y-6'
+      id='monkeys_editor_editor-container'
+    ></div>
   );
 });
 

--- a/apps/the_monkeys/src/components/editor/preview.tsx
+++ b/apps/the_monkeys/src/components/editor/preview.tsx
@@ -1,19 +1,19 @@
 import React, { FC, useEffect, useRef } from 'react';
 
-import { editorConfig } from '@/config/editor/editorjs_readonly.config';
+import { editorConfig } from '@/config/editor/monkeys_editor_readonly.config';
 import { Block } from '@/services/blog/blogTypes';
-import EditorJS from '@editorjs/editorjs';
+import MonkeysEditor from 'monkeys-editor';
 
 export type EditorProps = {
   data?: { time: number; blocks: Block[] };
 };
 
 const Editor: FC<EditorProps> = ({ data }) => {
-  const editorInstance = useRef<EditorJS | null>(null);
+  const editorInstance = useRef<MonkeysEditor | null>(null);
 
   useEffect(() => {
     if (!editorInstance.current) {
-      editorInstance.current = new EditorJS({
+      editorInstance.current = new MonkeysEditor({
         ...editorConfig,
         data: data,
       });
@@ -31,7 +31,7 @@ const Editor: FC<EditorProps> = ({ data }) => {
   return (
     <div
       className='mx-auto px-4 -mt-[30px] break-words'
-      id='editorjs_editor-container'
+      id='monkeys_editor_editor-container'
     ></div>
   );
 };

--- a/apps/the_monkeys/src/components/editor/preview.tsx
+++ b/apps/the_monkeys/src/components/editor/preview.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useRef } from 'react';
 
 import { editorConfig } from '@/config/editor/monkeys_editor_readonly.config';
 import { Block } from '@/services/blog/blogTypes';
-import MonkeysEditor from 'monkeys-editor';
+import MonkeysEditor from '@themonkeys/monkeys-editor';
 
 export type EditorProps = {
   data?: { time: number; blocks: Block[] };

--- a/apps/the_monkeys/src/config/editor/monkeys_editor.config.ts
+++ b/apps/the_monkeys/src/config/editor/monkeys_editor.config.ts
@@ -3,16 +3,16 @@ import CustomList from '@/components/editor/customBlocks/CustomListBlock';
 import CustomEmbed from '@/components/editor/customBlocks/EmbedBlock';
 import axiosInstanceV2 from '@/services/api/axiosInstanceV2';
 import Delimiter from '@editorjs/delimiter';
-import { EditorConfig } from '@editorjs/editorjs';
 import Header from '@editorjs/header';
 import Image from '@editorjs/image';
 import List from '@editorjs/list';
 import Paragraph from '@editorjs/paragraph';
 import Quote from '@editorjs/quote';
 import Table from '@editorjs/table';
+import { EditorConfig } from 'monkeys-editor';
 
 export const getEditorConfig = (blogId: string): EditorConfig => ({
-  holder: 'editorjs_editor-container',
+  holder: 'monkeys_editor_editor-container',
   tools: {
     header: {
       class: Header,

--- a/apps/the_monkeys/src/config/editor/monkeys_editor.config.ts
+++ b/apps/the_monkeys/src/config/editor/monkeys_editor.config.ts
@@ -9,7 +9,7 @@ import List from '@editorjs/list';
 import Paragraph from '@editorjs/paragraph';
 import Quote from '@editorjs/quote';
 import Table from '@editorjs/table';
-import { EditorConfig } from 'monkeys-editor';
+import { EditorConfig } from '@themonkeys/monkeys-editor';
 
 export const getEditorConfig = (blogId: string): EditorConfig => ({
   holder: 'monkeys_editor_editor-container',

--- a/apps/the_monkeys/src/config/editor/monkeys_editor_readonly.config.ts
+++ b/apps/the_monkeys/src/config/editor/monkeys_editor_readonly.config.ts
@@ -3,16 +3,16 @@ import CustomList from '@/components/editor/customBlocks/CustomListBlock';
 import CustomEmbed from '@/components/editor/customBlocks/EmbedBlock';
 import TitleBlockTool from '@/components/editor/customBlocks/TitleBlock';
 import Delimiter from '@editorjs/delimiter';
-import { EditorConfig } from '@editorjs/editorjs';
 import Header from '@editorjs/header';
 import Image from '@editorjs/image';
 import List from '@editorjs/list';
 import Paragraph from '@editorjs/paragraph';
 import Quote from '@editorjs/quote';
 import Table from '@editorjs/table';
+import { EditorConfig } from 'monkeys-editor';
 
 export const editorConfig: EditorConfig = {
-  holder: 'editorjs_editor-container',
+  holder: 'monkeys_editor_editor-container',
   readOnly: true,
   tools: {
     header: {

--- a/apps/the_monkeys/src/config/editor/monkeys_editor_readonly.config.ts
+++ b/apps/the_monkeys/src/config/editor/monkeys_editor_readonly.config.ts
@@ -9,7 +9,7 @@ import List from '@editorjs/list';
 import Paragraph from '@editorjs/paragraph';
 import Quote from '@editorjs/quote';
 import Table from '@editorjs/table';
-import { EditorConfig } from 'monkeys-editor';
+import { EditorConfig } from '@themonkeys/monkeys-editor';
 
 export const editorConfig: EditorConfig = {
   holder: 'monkeys_editor_editor-container',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@the-monkeys/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@themonkeys/monkeys-editor':
+        specifier: 1.0.1
+        version: 1.0.1
       axios:
         specifier: ^1.6.8
         version: 1.8.4
@@ -108,9 +111,6 @@ importers:
       moment:
         specifier: ^2.30.1
         version: 2.30.1
-      monkeys-editor:
-        specifier: link:/home/gautam/Desktop/editor
-        version: link:../../../editor
       next:
         specifier: ^14.2.13
         version: 14.2.26(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1864,6 +1864,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@themonkeys/monkeys-editor@1.0.1':
+    resolution: {integrity: sha512-2ckZs/3+qPkQXjNCLv8Sw9oLbd14nXOvc0NW+KcsvVvKXrSs/DPXcMUDSqS+G6R5oNwueWWWgsWWBP8cBk24Xg==}
+
   '@trivago/prettier-plugin-sort-imports@4.3.0':
     resolution: {integrity: sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==}
     peerDependencies:
@@ -2099,6 +2102,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-darwin-arm64@1.3.2':
     resolution: {integrity: sha512-ddnlXgRi0Fog5+7U5Q1qY62wl95Q1lB4tXQX1UIA9YHmRCHN2twaQW0/4tDVGCvTVEU3xEayU7VemEr7GcBYUw==}
@@ -3241,15 +3245,17 @@ packages:
   glob@10.3.10:
     resolution: {integrity: sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -4762,6 +4768,7 @@ packages:
   tsconfck@3.1.5:
     resolution: {integrity: sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -6577,6 +6584,8 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
+  '@themonkeys/monkeys-editor@1.0.1': {}
+
   '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.2.5)':
     dependencies:
       '@babel/generator': 7.17.7
@@ -7796,7 +7805,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -7830,7 +7839,7 @@ snapshots:
       tinyglobby: 0.2.12
       unrs-resolver: 1.3.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7845,7 +7854,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
       '@editorjs/delimiter':
         specifier: 1.4.2
         version: 1.4.2
-      '@editorjs/editorjs':
-        specifier: 2.29.1
-        version: 2.29.1
       '@editorjs/header':
         specifier: 2.8.1
         version: 2.8.1
@@ -111,6 +108,9 @@ importers:
       moment:
         specifier: ^2.30.1
         version: 2.30.1
+      monkeys-editor:
+        specifier: link:/home/gautam/Desktop/editor
+        version: link:../../../editor
       next:
         specifier: ^14.2.13
         version: 14.2.26(@babel/core@7.26.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -572,9 +572,6 @@ packages:
 
   '@editorjs/dom@0.0.5':
     resolution: {integrity: sha512-SZ78Gwpkp3EUhjBIp0lSojeQ35V9acF8SubJsMeOH/vlOUE40GOnvvwWZnF05lO7bIB0dOHhhJy4N7IIAWxP2w==}
-
-  '@editorjs/editorjs@2.29.1':
-    resolution: {integrity: sha512-WRT2pCfikMsvySQJqpCU21LfTZaPuxUWsDO8aFGrPx4MKzOR9D+Ur4mNb3jq0FXx2EMqvIWfTyFixJxtjGHTyQ==}
 
   '@editorjs/header@2.8.1':
     resolution: {integrity: sha512-y0HVXRP7m2W617CWo3fsb5HhXmSLaRpb9GzFx0Vkp/HEm9Dz5YO1s8tC7R8JD3MskwoYh7V0hRFQt39io/r6hA==}
@@ -5410,8 +5407,6 @@ snapshots:
     dependencies:
       '@editorjs/helpers': 0.0.4
 
-  '@editorjs/editorjs@2.29.1': {}
-
   '@editorjs/header@2.8.1':
     dependencies:
       '@codexteam/icons': 0.0.5
@@ -7801,7 +7796,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -7835,7 +7830,7 @@ snapshots:
       tinyglobby: 0.2.12
       unrs-resolver: 1.3.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7850,7 +7845,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8


### PR DESCRIPTION
### 📃 Why Merge This PR?

This PR migrates the frontend application's core editor dependency from the original `@editorjs/editorjs` to our newly rebranded and published fork, `@themonkeys/monkeys-editor`.

**Key Changes:**

* Published version `1.0.0` of `@themonkeys/monkeys-editor` to the public NPM registry.
* Uninstalled `@editorjs/editorjs` and installed `@themonkeys/monkeys-editor` in the `the_monkeys` frontend workspace.
* Refactored all import paths across components, type definitions, and configurations to point to the new package.
* Formatted the codebase to ensure `prettier` and `eslint` compliance with the new import names.

### 🛠️ Issue Fixed

fixes the-monkeys/the_monkeys#575

### 🔍 PR Type

- [ ] 💡 Feature
- [ ] 🐛 Bug Fix
- [ ] 📃 Documentation
- [ ] 🎨 UI Improvements
- [X] 💻 Code Refactor
- [ ] ✅ Tests