### PR TITLE
add edit button for owner to edit blog on view page itself

### DIFF
--- a/apps/the_monkeys/src/app/blog/[slug]/BlogPageClient.tsx
+++ b/apps/the_monkeys/src/app/blog/[slug]/BlogPageClient.tsx
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 
 import AdUnit from '@/components/AdSense/AdUnit';
+import { EditBlogButton } from '@/components/blog/actions/EditBlogDialog';
 import { BlogHeading, getCardContent } from '@/components/blog/getBlogContent';
 import { BackButton } from '@/components/buttons/backButton';
 import { AuthorInfoCard } from '@/components/cards/author/AuthorInfoCard';
@@ -18,6 +19,7 @@ import {
 import { SocialSnapshotCard } from '@/components/social/SocialSnapshot';
 import { TopicLinksContainerCompact } from '@/components/topics/topicsContainer';
 import { UserInfoCardBlogPage } from '@/components/user/userInfo';
+import useAuth from '@/hooks/auth/useAuth';
 import useGetPublishedBlogDetailByBlogId from '@/hooks/blog/useGetPublishedBlogDetailByBlogId';
 import useGetProfileInfoById from '@/hooks/user/useGetProfileInfoByUserId';
 import { purifyHTMLString } from '@/utils/purifyHTML';
@@ -38,11 +40,13 @@ interface BlogPageClientProps {
 
 const BlogPageClient = ({ urlBlogId, fullSlug }: BlogPageClientProps) => {
   const router = useRouter();
+  const { data: session } = useAuth();
   const { blog, isError, isLoading } =
     useGetPublishedBlogDetailByBlogId(urlBlogId);
   const authorId = blog?.owner_account_id;
 
   const { user } = useGetProfileInfoById(authorId);
+  const isOwner = !!session?.account_id && authorId === session?.account_id;
 
   useEffect(() => {
     const startTime = Date.now();
@@ -137,8 +141,11 @@ const BlogPageClient = ({ urlBlogId, fullSlug }: BlogPageClientProps) => {
   return (
     <>
       <div className='px-4'>
-        <Container className='pt-6 max-w-4xl'>
+        <Container className='pt-6 max-w-4xl flex items-center justify-between'>
           <BackButton />
+          {isOwner && (
+            <EditBlogButton blogId={urlBlogId} variant='outline' label='Edit' />
+          )}
         </Container>
       </div>
       <div className='px-4'>

--- a/apps/the_monkeys/src/components/blog/actions/EditBlogDialog.tsx
+++ b/apps/the_monkeys/src/components/blog/actions/EditBlogDialog.tsx
@@ -9,6 +9,7 @@ import { Loader } from '@/components/loader';
 import useAuth from '@/hooks/auth/useAuth';
 import { ALL_DRAFT_BLOGS_QUERY_KEY } from '@/hooks/blog/useGetAllDraftBlogs';
 import { BLOGS_BY_USERNAME_QUERY_KEY } from '@/hooks/blog/useGetPublishedBlogByUsername';
+import { cn } from '@/lib/utils';
 import axiosInstanceV2 from '@/services/api/axiosInstanceV2';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@the-monkeys/ui/atoms/button';
@@ -21,7 +22,25 @@ import {
 } from '@the-monkeys/ui/atoms/dialog';
 import { toast } from '@the-monkeys/ui/hooks/use-toast';
 
-export const EditBlogDialog = ({ blogId }: { blogId: string }) => {
+export interface EditBlogButtonProps {
+  blogId: string;
+  isDraft?: boolean;
+  children?: React.ReactNode;
+  variant?: 'icon' | 'button' | 'outline' | 'ghost' | 'secondary';
+  className?: string;
+  label?: string;
+  iconSize?: number;
+}
+
+export const EditBlogButton = ({
+  blogId,
+  isDraft = false,
+  children,
+  variant = 'icon',
+  className,
+  label,
+  iconSize = 18,
+}: EditBlogButtonProps) => {
   const queryClient = useQueryClient();
   const { data: session } = useAuth();
   const [isLoading, setIsLoading] = React.useState<{
@@ -95,16 +114,62 @@ export const EditBlogDialog = ({ blogId }: { blogId: string }) => {
     }
   }
 
+  const renderTriggerContent = () => {
+    if (children) return children;
+
+    if (
+      variant === 'button' ||
+      variant === 'outline' ||
+      variant === 'ghost' ||
+      variant === 'secondary'
+    ) {
+      return (
+        <Button
+          type='button'
+          variant={variant === 'button' ? 'default' : variant}
+          className={cn('flex items-center gap-2', className)}
+          title={isDraft ? 'Edit Draft' : 'Convert & Edit'}
+        >
+          <Icon name='RiPencil' size={iconSize} />
+          {label || (isDraft ? 'Edit Draft' : 'Edit Post')}
+        </Button>
+      );
+    }
+
+    return (
+      <button
+        type='button'
+        className={cn(
+          'p-1 flex items-center justify-center cursor-pointer opacity-80 hover:opacity-100',
+          className
+        )}
+        title={isDraft ? 'Edit Draft' : 'Convert to Draft'}
+      >
+        <Icon name='RiPencil' size={iconSize} />
+        {label && <span className='ml-1.5 text-sm'>{label}</span>}
+      </button>
+    );
+  };
+
+  if (isDraft) {
+    if (children) {
+      return (
+        <span
+          onClick={() => handleEdit(blogId)}
+          className={cn('cursor-pointer', className)}
+        >
+          {children}
+        </span>
+      );
+    }
+    return (
+      <span onClick={() => handleEdit(blogId)}>{renderTriggerContent()}</span>
+    );
+  }
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <button
-          className='p-1 flex items-center justify-center cursor-pointer opacity-80 hover:opacity-100'
-          title='Convert to Draft'
-        >
-          <Icon name='RiPencil' size={18} />
-        </button>
-      </DialogTrigger>
+      <DialogTrigger asChild>{renderTriggerContent()}</DialogTrigger>
 
       <DialogContent>
         <DialogTitle>Move to Draft?</DialogTitle>
@@ -144,3 +209,5 @@ export const EditBlogDialog = ({ blogId }: { blogId: string }) => {
     </Dialog>
   );
 };
+
+export const EditBlogDialog = EditBlogButton;

--- a/apps/the_monkeys/src/components/cards/blog/ProfileBlogCard.tsx
+++ b/apps/the_monkeys/src/components/cards/blog/ProfileBlogCard.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation';
 import { generateSlug } from '@/app/blog/utils/generateSlug';
 import { BlogShareDialog } from '@/components/blog/actions/BlogShareDialog';
 import { DeleteBlogDialog } from '@/components/blog/actions/DeleteBlogDialog';
-import { EditBlogDialog } from '@/components/blog/actions/EditBlogDialog';
+import { EditBlogButton } from '@/components/blog/actions/EditBlogDialog';
 import {
   BlogDescription,
   BlogImage,
@@ -131,18 +131,8 @@ export const ProfileBlogCard = ({
             </div>
 
             <div className='flex items-center gap-2'>
-              {showModificationOptions && !isDraft && (
-                <EditBlogDialog blogId={blogId} />
-              )}
-
-              {showModificationOptions && isDraft && (
-                <button
-                  onClick={() => handleEdit(blogId)}
-                  className='p-1 flex items-center justify-center cursor-pointer opacity-80 hover:opacity-100'
-                  title='Edit Draft'
-                >
-                  <Icon name='RiEdit2' size={18} />
-                </button>
+              {showModificationOptions && (
+                <EditBlogButton blogId={blogId} isDraft={isDraft} />
               )}
 
               {showModificationOptions && (


### PR DESCRIPTION
### 📃 Why Merge This PR?

This PR adds an **Edit** button to the blog details page for blog authors. The page now checks whether the logged-in user's ID matches the blog author's ID and conditionally displays the **Edit** button. Clicking the button redirects the author to the existing blog edit page.

The implementation is responsive, reuses the current edit flow without introducing new endpoints, and maintains proper authorization by relying on existing server-side validation to prevent unauthorized edits.

### 🛠️ Issue Fixed

Fixes #593 

### 🔍 PR Type

* [x] 💡 Feature
* [x] 🎨 UI Improvements
* [ ] 🐛 Bug Fix
* [ ] 📃 Documentation
* [ ] 💻 Code Refactor
* [ ] ✅ Tests

