### PR TITLE
bump: react-day-picker package

### DIFF
--- a/apps/the_monkeys/src/app/settings/components/Profile.tsx
+++ b/apps/the_monkeys/src/app/settings/components/Profile.tsx
@@ -247,9 +247,9 @@ export const Profile = ({ data }: { data?: IUser }) => {
                               field.onChange(formattedDate);
                             }
                           }}
-                          captionLayout='dropdown-buttons'
-                          fromYear={1960}
-                          toYear={new Date().getFullYear()}
+                          captionLayout='dropdown'
+                          startMonth={new Date(1960, 0)}
+                          endMonth={new Date(new Date().getFullYear(), 11)}
                         />
                       </PopoverContent>
                     </Popover>

--- a/apps/the_monkeys/src/components/blog/ScheduleDateTimePicker.tsx
+++ b/apps/the_monkeys/src/components/blog/ScheduleDateTimePicker.tsx
@@ -67,8 +67,9 @@ const ScheduleDateTimePicker = ({
                 mode='single'
                 selected={scheduleDate}
                 onSelect={onDateChange}
-                fromDate={new Date()}
-                initialFocus
+                startMonth={new Date()}
+                disabled={{ before: new Date() }}
+                autoFocus
               />
             </PopoverContent>
           </Popover>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,6 +13,7 @@
 		"format": "biome check --write ."
 	},
 	"dependencies": {
+		"@daypicker/react": "^10.0.1",
 		"@radix-ui/react-accordion": "^1.2.13",
 		"@radix-ui/react-dialog": "^1.1.2",
 		"@radix-ui/react-dropdown-menu": "^2.0.6",
@@ -32,7 +33,6 @@
 		"clsx": "^2.1.0",
 		"embla-carousel-react": "^8.3.0",
 		"react": "^18",
-		"react-day-picker": "^8.10.1",
 		"react-dom": "^18",
 		"react-hook-form": "^7.51.4",
 		"tailwind-merge": "^2.2.2",

--- a/packages/ui/src/organism/calendar.tsx
+++ b/packages/ui/src/organism/calendar.tsx
@@ -27,36 +27,42 @@ function Calendar({
 		<DayPicker
 			showOutsideDays={showOutsideDays}
 			className={cn(
-				"px-4 py-2 bg-background-light dark:bg-background-dark border border-foreground-light dark:border-foreground-dark rounded-md shadow-md",
+				"relative p-4 bg-background-light dark:bg-background-dark border border-foreground-light dark:border-foreground-dark rounded-xl shadow-md",
 				className,
 			)}
 			classNames={{
-				months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
-				month: "space-y-4",
-				month_caption: "flex justify-center pt-1 relative items-center",
-				caption_label: "text-sm font-medium",
-				dropdowns: "flex justify-center gap-1",
-				nav: "space-x-1 flex items-center",
+				months: "flex flex-col sm:flex-row gap-4",
+				month: "w-full space-y-3",
+				nav: "absolute inset-x-0 top-0 flex items-center justify-between pointer-events-none",
+
 				button_previous: cn(
 					buttonVariants({ variant: "outline" }),
-					"size-8 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1",
+					"pointer-events-auto size-8 bg-transparent p-0 opacity-70 hover:opacity-100 absolute left-6 top-4",
 				),
 				button_next: cn(
 					buttonVariants({ variant: "outline" }),
-					"size-8 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1",
+					"pointer-events-auto size-8 bg-transparent p-0 opacity-70 hover:opacity-100 absolute right-6 top-4",
 				),
-				month_grid: "w-full border-collapse space-y-1",
-				weekdays: "flex space-x-1",
+
+				month_caption: "flex h-8 items-center justify-center mx-10",
+				caption_label: "text-sm font-medium",
+				dropdowns: "flex items-center justify-center gap-1",
+
+				month_grid: "w-full border-collapse mt-2",
+				weekdays: "grid grid-cols-7",
 				weekday:
-					"font-dm_sans text-text-light/80 dark:text-text-dark/80 rounded-md w-9 font-normal text-sm",
-				week: "flex w-full mt-2 space-x-1",
-				day: "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
-				day_button: cn(buttonVariants({ variant: "ghost" }), "h-9 w-9 p-0"),
+					"font-dm_sans text-text-light/60 dark:text-text-dark/60 font-normal text-sm text-center py-2",
+				week: "grid grid-cols-7 mt-1",
+				day: "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-md last:[&:has([aria-selected])]:rounded-md focus-within:relative focus-within:z-20",
+				day_button: cn(
+					buttonVariants({ variant: "ghost" }),
+					"h-10 w-10 mx-auto rounded-md p-0 font-normal",
+				),
 				selected:
 					"bg-foreground-light dark:bg-foreground-dark hover:bg-primary",
 				today: "bg-accent text-accent-foreground",
-				outside: "opacity-50",
-				disabled: "opacity-50",
+				outside: "opacity-40",
+				disabled: "opacity-40",
 				range_middle:
 					"aria-selected:bg-accent aria-selected:text-accent-foreground",
 				hidden: "invisible",

--- a/packages/ui/src/organism/calendar.tsx
+++ b/packages/ui/src/organism/calendar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import * as React from "react";
+import type * as React from "react";
 
-import { DayPicker, type DropdownProps } from "react-day-picker";
+import { DayPicker, type DropdownProps } from "@daypicker/react";
 import { buttonVariants } from "../atoms/button";
 import { ScrollArea } from "../atoms/scroll-area";
 import {
@@ -33,40 +33,38 @@ function Calendar({
 			classNames={{
 				months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
 				month: "space-y-4",
-				caption: "flex justify-center pt-1 relative items-center",
+				month_caption: "flex justify-center pt-1 relative items-center",
 				caption_label: "text-sm font-medium",
-				caption_dropdowns: "flex justify-center gap-1",
+				dropdowns: "flex justify-center gap-1",
 				nav: "space-x-1 flex items-center",
-				nav_button: cn(
+				button_previous: cn(
 					buttonVariants({ variant: "outline" }),
-					"size-8 bg-transparent p-0 opacity-50 hover:opacity-100",
+					"size-8 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1",
 				),
-				nav_button_previous: "absolute left-1",
-				nav_button_next: "absolute right-1",
-				table: "w-full border-collapse space-y-1",
-				head_row: "flex space-x-1",
-				head_cell:
+				button_next: cn(
+					buttonVariants({ variant: "outline" }),
+					"size-8 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1",
+				),
+				month_grid: "w-full border-collapse space-y-1",
+				weekdays: "flex space-x-1",
+				weekday:
 					"font-dm_sans text-text-light/80 dark:text-text-dark/80 rounded-md w-9 font-normal text-sm",
-				row: "flex w-full mt-2 space-x-1",
-				cell: "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
-				day: cn(buttonVariants({ variant: "ghost" }), "h-9 w-9 p-0"),
-				day_selected:
+				week: "flex w-full mt-2 space-x-1",
+				day: "text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+				day_button: cn(buttonVariants({ variant: "ghost" }), "h-9 w-9 p-0"),
+				selected:
 					"bg-foreground-light dark:bg-foreground-dark hover:bg-primary",
-				day_today: "bg-accent text-accent-foreground",
-				day_outside: "opacity-50",
-				day_disabled: "opacity-50",
-				day_range_middle:
+				today: "bg-accent text-accent-foreground",
+				outside: "opacity-50",
+				disabled: "opacity-50",
+				range_middle:
 					"aria-selected:bg-accent aria-selected:text-accent-foreground",
-				day_hidden: "invisible",
+				hidden: "invisible",
 				...classNames,
 			}}
 			components={{
-				Dropdown: ({ value, onChange, children }: DropdownProps) => {
-					const options = React.Children.toArray(
-						children,
-					) as React.ReactElement<React.HTMLProps<HTMLOptionElement>>[];
-
-					const selected = options.find((child) => child.props.value === value);
+				Dropdown: ({ value, onChange, options }: DropdownProps) => {
+					const selected = options?.find((child) => child.value === value);
 
 					const handleChange = (value: string) => {
 						const changeEvent = {
@@ -83,17 +81,18 @@ function Calendar({
 							}}
 						>
 							<SelectTrigger className="font-dm_sans bg-background-light dark:bg-background-dark">
-								<SelectValue>{selected?.props?.children}</SelectValue>
+								<SelectValue>{selected?.label}</SelectValue>
 							</SelectTrigger>
 
 							<SelectContent position="popper">
 								<ScrollArea className="h-[200px] m-0 outline-none">
-									{options.map((option, id: number) => (
+									{options?.map((option, id: number) => (
 										<SelectItem
-											key={`${option.props.value}-${id}`}
-											value={option.props.value?.toString() ?? ""}
+											key={`${option.value}-${id}`}
+											value={option.value?.toString() ?? ""}
+											disabled={option.disabled}
 										>
-											{option.props.children}
+											{option.label}
 										</SelectItem>
 									))}
 								</ScrollArea>
@@ -101,8 +100,12 @@ function Calendar({
 						</Select>
 					);
 				},
-				IconLeft: () => <AngleLeft size={18} />,
-				IconRight: () => <AngleRight size={18} />,
+				Chevron: (props) => {
+					if (props?.orientation === "left") {
+						return <AngleLeft size={18} />;
+					}
+					return <AngleRight size={18} />;
+				},
 			}}
 			{...props}
 		/>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,6 +264,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@daypicker/react':
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@18.3.20)(react@18.3.1)
       '@radix-ui/react-accordion':
         specifier: ^1.2.13
         version: 1.2.13(@types/react-dom@18.3.5(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -321,9 +324,6 @@ importers:
       react:
         specifier: ^18
         version: 18.3.1
-      react-day-picker:
-        specifier: ^8.10.1
-        version: 8.10.1(date-fns@3.6.0)(react@18.3.1)
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
@@ -566,6 +566,19 @@ packages:
   '@csstools/css-tokenizer@3.0.3':
     resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
     engines: {node: '>=18'}
+
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
+
+  '@daypicker/react@10.0.1':
+    resolution: {integrity: sha512-lH4YQz4iMBWP8hsI1bD9Eg0T7t503IkSUR/WDGGkV5mKZvwVv+ukCkJz7yN+uVFBv7vHTK+ww7a5EvlkeFwPYQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@editorjs/delimiter@1.4.2':
     resolution: {integrity: sha512-S8q2LpeYdYkVShLp7K8c4HLthDHBevLw+sT+iO0+SH0oMvFmld9SUon3DFzMQ2gG07EOdZGRZ958+sVxyvFjZw==}
@@ -2705,6 +2718,9 @@ packages:
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -4249,11 +4265,15 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  react-day-picker@8.10.1:
-    resolution: {integrity: sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==}
+  react-day-picker@10.0.1:
+    resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
+    engines: {node: '>=18'}
     peerDependencies:
-      date-fns: ^2.28.0 || ^3.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -5405,6 +5425,15 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
 
   '@csstools/css-tokenizer@3.0.3': {}
+
+  '@date-fns/tz@1.5.0': {}
+
+  '@daypicker/react@10.0.1(@types/react@18.3.20)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-day-picker: 10.0.1(@types/react@18.3.20)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.20
 
   '@editorjs/delimiter@1.4.2':
     dependencies:
@@ -7506,6 +7535,8 @@ snapshots:
 
   date-fns@3.6.0: {}
 
+  date-fns@4.4.0: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -9381,10 +9412,13 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  react-day-picker@8.10.1(date-fns@3.6.0)(react@18.3.1):
+  react-day-picker@10.0.1(@types/react@18.3.20)(react@18.3.1):
     dependencies:
-      date-fns: 3.6.0
+      '@date-fns/tz': 1.5.0
+      date-fns: 4.4.0
       react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.20
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:


### PR DESCRIPTION
### 📃 Why Merge This PR?

Version 8.10.1 is no longer supported, it is giving unmet peer warning in console while updating our Next.js to version 15.x.xx and react to version 19.x.xx. I've updated react-day-picker package to latest version (10.0.1) and refactored the component's code related to it.

### 🛠️ Issue Fixed

Fixes the-monkeys/the_monkeys#651

### 🔍 PR Type

- [ ] 💡 Feature
- [ ] 🐛 Bug Fix
- [ ] 📃 Documentation
- [ ] 🎨 UI Improvements
- [X] 💻 Code Refactor
- [ ] ✅ Tests