### PR TITLE
change blog schedule time method

### DIFF
--- a/apps/the_monkeys/src/app/topics/[topic]/components/BlogsByTopic.tsx
+++ b/apps/the_monkeys/src/app/topics/[topic]/components/BlogsByTopic.tsx
@@ -33,7 +33,7 @@ export const BlogsByTopic = ({ topic }: { topic: string }) => {
     };
 
     fetchBlogs();
-  }, []);
+  }, [topic]);
 
   if (blogsLoading) {
     return <FeedBlogCardListSkeleton />;

--- a/apps/the_monkeys/src/components/blog/ScheduleDateTimePicker.tsx
+++ b/apps/the_monkeys/src/components/blog/ScheduleDateTimePicker.tsx
@@ -116,7 +116,8 @@ const ScheduleDateTimePicker = ({
           {isPast ? (
             <div className='p-3 text-xs rounded-md bg-alert-red/10 border border-alert-red/20 text-alert-red space-y-1'>
               <p className='font-medium'>
-                ⚠️ Selected time is in the past for this timezone. Please choose a future time.
+                ⚠️ Selected time is in the past for this timezone. Please choose
+                a future time.
               </p>
             </div>
           ) : (
@@ -138,4 +139,3 @@ const ScheduleDateTimePicker = ({
 };
 
 export default ScheduleDateTimePicker;
-

--- a/apps/the_monkeys/src/components/blog/ScheduleDateTimePicker.tsx
+++ b/apps/the_monkeys/src/components/blog/ScheduleDateTimePicker.tsx
@@ -1,3 +1,4 @@
+import { getZonedDate } from '@/hooks/blog/schedule/useScheduleState';
 import { Button } from '@the-monkeys/ui/atoms/button';
 import { Input } from '@the-monkeys/ui/atoms/input';
 import { Label } from '@the-monkeys/ui/atoms/label';
@@ -7,7 +8,7 @@ import {
   PopoverTrigger,
 } from '@the-monkeys/ui/atoms/popover';
 import { Calendar } from '@the-monkeys/ui/organism/calendar';
-import { format } from 'date-fns';
+import { format, formatDistanceToNow } from 'date-fns';
 import { twMerge } from 'tailwind-merge';
 
 import FormSearchSelect from '../FormSearchSelect';
@@ -39,6 +40,14 @@ const ScheduleDateTimePicker = ({
       onTimezoneChange(selected.value);
     }
   };
+
+  const combinedDateTime = getZonedDate(
+    scheduleDate,
+    scheduleTime,
+    selectedTimezone
+  );
+  const isValid = combinedDateTime ? !isNaN(combinedDateTime.getTime()) : false;
+  const isPast = combinedDateTime && isValid ? combinedDateTime <= new Date() : false;
 
   return (
     <div className='space-y-4 animate-in fade-in slide-in-from-top-2 duration-200'>
@@ -99,8 +108,31 @@ const ScheduleDateTimePicker = ({
           placeholder='Select Timezone'
         />
       </div>
+
+      {/* Schedule Live Preview Feedback */}
+      {combinedDateTime && isValid && (
+        <>
+          {isPast ? (
+            <div className='p-3 text-xs rounded-md bg-alert-red/10 border border-alert-red/20 text-alert-red space-y-1'>
+              <p className='font-medium'>
+                ⚠️ Selected time is in the past for this timezone. Please choose a future time.
+              </p>
+            </div>
+          ) : (
+            <div className='p-3 text-xs rounded-md bg-muted/60 border border-border/60 space-y-1 text-muted-foreground'>
+              <p className='font-medium text-foreground flex items-center gap-1.5'>
+                <span>📅</span> Will be published {formatDistanceToNow(combinedDateTime, { addSuffix: true })}
+              </p>
+              <p>Target ({selectedTimezone}): {format(combinedDateTime, 'PPpp')}</p>
+              <p>Universal (UTC): {combinedDateTime.toUTCString()}</p>
+            </div>
+          )}
+        </>
+      )}
     </div>
   );
 };
 
 export default ScheduleDateTimePicker;
+
+

--- a/apps/the_monkeys/src/components/blog/ScheduleDateTimePicker.tsx
+++ b/apps/the_monkeys/src/components/blog/ScheduleDateTimePicker.tsx
@@ -47,7 +47,8 @@ const ScheduleDateTimePicker = ({
     selectedTimezone
   );
   const isValid = combinedDateTime ? !isNaN(combinedDateTime.getTime()) : false;
-  const isPast = combinedDateTime && isValid ? combinedDateTime <= new Date() : false;
+  const isPast =
+    combinedDateTime && isValid ? combinedDateTime <= new Date() : false;
 
   return (
     <div className='space-y-4 animate-in fade-in slide-in-from-top-2 duration-200'>
@@ -121,9 +122,12 @@ const ScheduleDateTimePicker = ({
           ) : (
             <div className='p-3 text-xs rounded-md bg-muted/60 border border-border/60 space-y-1 text-muted-foreground'>
               <p className='font-medium text-foreground flex items-center gap-1.5'>
-                <span>📅</span> Will be published {formatDistanceToNow(combinedDateTime, { addSuffix: true })}
+                <span>📅</span> Will be published{' '}
+                {formatDistanceToNow(combinedDateTime, { addSuffix: true })}
               </p>
-              <p>Target ({selectedTimezone}): {format(combinedDateTime, 'PPpp')}</p>
+              <p>
+                Target ({selectedTimezone}): {format(combinedDateTime, 'PPpp')}
+              </p>
               <p>Universal (UTC): {combinedDateTime.toUTCString()}</p>
             </div>
           )}
@@ -134,5 +138,4 @@ const ScheduleDateTimePicker = ({
 };
 
 export default ScheduleDateTimePicker;
-
 

--- a/apps/the_monkeys/src/components/search/SearchInput.tsx
+++ b/apps/the_monkeys/src/components/search/SearchInput.tsx
@@ -68,8 +68,8 @@ export const SearchInput = ({ className }: { className?: string }) => {
             name='RiSearch'
             size={18}
             className={twMerge(
-              'text-gray-400  transition-colors',
-              focused && 'text-gray-900'
+              "text-gray-400 dark:text-gray-500 transition-colors",
+              focused && "text-gray-900 dark:text-gray-100"
             )}
           />
 

--- a/apps/the_monkeys/src/components/search/SearchInput.tsx
+++ b/apps/the_monkeys/src/components/search/SearchInput.tsx
@@ -68,8 +68,8 @@ export const SearchInput = ({ className }: { className?: string }) => {
             name='RiSearch'
             size={18}
             className={twMerge(
-              "text-gray-400 dark:text-gray-500 transition-colors",
-              focused && "text-gray-900 dark:text-gray-100"
+              'text-gray-400·dark:text-gray-500·transition-colors',
+              focused && 'text-gray-900·dark:text-gray-100'
             )}
           />
 

--- a/apps/the_monkeys/src/components/search/SearchInput.tsx
+++ b/apps/the_monkeys/src/components/search/SearchInput.tsx
@@ -74,13 +74,13 @@ export const SearchInput = ({ className }: { className?: string }) => {
           />
 
           <input
-            value={searchQuery}
-            placeholder='Search stories...'
-            className='w-full text-[15px] bg-transparent  focus:outline-none text-gray-900 placeholder:text-gray-400 font-inter'
-            onChange={handleInputChange}
-            onFocus={() => setFocused(true)}
-            onBlur={handleBlur}
-          />
+             value={searchQuery}
+              placeholder='Search stories...'
+              className='w-full text-[15px] bg-transparent focus:outline-none text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 font-inter'
+              onChange={handleInputChange}
+              onFocus={() => setFocused(true)}
+              onBlur={handleBlur}
+            />
 
           {searchQuery.trim() && (
             <button

--- a/apps/the_monkeys/src/components/search/SearchInput.tsx
+++ b/apps/the_monkeys/src/components/search/SearchInput.tsx
@@ -74,13 +74,13 @@ export const SearchInput = ({ className }: { className?: string }) => {
           />
 
           <input
-             value={searchQuery}
-              placeholder='Search stories...'
-              className='w-full text-[15px] bg-transparent focus:outline-none text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 font-inter'
-              onChange={handleInputChange}
-              onFocus={() => setFocused(true)}
-              onBlur={handleBlur}
-            />
+            value={searchQuery}
+            placeholder='Search stories...'
+            className='w-full text-[15px] bg-transparent focus:outline-none text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 font-inter'
+            onChange={handleInputChange}
+            onFocus={() => setFocused(true)}
+            onBlur={handleBlur}
+          />
 
           {searchQuery.trim() && (
             <button

--- a/apps/the_monkeys/src/features/snapshot/components/TweetScreenshotPreview.tsx
+++ b/apps/the_monkeys/src/features/snapshot/components/TweetScreenshotPreview.tsx
@@ -574,7 +574,7 @@ export const TweetScreenshotPreview = forwardRef<
       overflow: 'hidden' as const,
       flexShrink: 0,
     }),
-    [width, height, options.backgroundColor, options.backgroundImage]
+    [width, height, options]
   );
 
   const placeholder = (message: string, sub?: string) => (

--- a/apps/the_monkeys/src/hooks/blog/schedule/useScheduleState.ts
+++ b/apps/the_monkeys/src/hooks/blog/schedule/useScheduleState.ts
@@ -102,4 +102,3 @@ export const useScheduleState = () => {
     validateAndSubmit,
   };
 };
-

--- a/apps/the_monkeys/src/hooks/blog/schedule/useScheduleState.ts
+++ b/apps/the_monkeys/src/hooks/blog/schedule/useScheduleState.ts
@@ -34,6 +34,15 @@ export const useScheduleState = () => {
       return;
     }
 
+    if (dateTime <= new Date()) {
+      toast({
+        variant: 'destructive',
+        title: 'Invalid Schedule',
+        description: 'Please choose a date and time in the future.',
+      });
+      return;
+    }
+
     onSubmit(dateTime.toISOString(), selectedTimezone);
   };
 

--- a/apps/the_monkeys/src/hooks/blog/schedule/useScheduleState.ts
+++ b/apps/the_monkeys/src/hooks/blog/schedule/useScheduleState.ts
@@ -3,6 +3,53 @@ import { useState } from 'react';
 import { toast } from '@the-monkeys/ui/hooks/use-toast';
 import { format } from 'date-fns';
 
+export const getZonedDate = (
+  scheduleDate: Date | undefined,
+  scheduleTime: string,
+  timeZone: string
+): Date | null => {
+  if (!scheduleDate || !scheduleTime) return null;
+  try {
+    const dateStr = format(scheduleDate, 'yyyy-MM-dd');
+    const targetIso = `${dateStr}T${scheduleTime}:00.000`;
+    const utcDate = new Date(`${targetIso}Z`);
+    if (isNaN(utcDate.getTime())) return null;
+
+    const formatter = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+
+    const parts = formatter.formatToParts(utcDate);
+    const partMap: Record<string, string> = {};
+    parts.forEach((p) => {
+      partMap[p.type] = p.value;
+    });
+
+    const tzYear = partMap.year;
+    const tzMonth = partMap.month;
+    const tzDay = partMap.day;
+    let tzHour = partMap.hour;
+    if (tzHour === '24') tzHour = '00';
+    const tzMinute = partMap.minute;
+
+    const tzAsUtc = new Date(
+      `${tzYear}-${tzMonth}-${tzDay}T${tzHour}:${tzMinute}:00.000Z`
+    );
+    const offsetMs = utcDate.getTime() - tzAsUtc.getTime();
+
+    return new Date(utcDate.getTime() + offsetMs);
+  } catch {
+    return null;
+  }
+};
+
 export const useScheduleState = () => {
   const [scheduleDate, setScheduleDate] = useState<Date | undefined>(undefined);
   const [scheduleTime, setScheduleTime] = useState<string>('');
@@ -22,10 +69,9 @@ export const useScheduleState = () => {
       return;
     }
 
-    const dateStr = format(scheduleDate, 'yyyy-MM-dd');
-    const dateTime = new Date(`${dateStr}T${scheduleTime}`);
+    const dateTime = getZonedDate(scheduleDate, scheduleTime, selectedTimezone);
 
-    if (isNaN(dateTime.getTime())) {
+    if (!dateTime || isNaN(dateTime.getTime())) {
       toast({
         variant: 'destructive',
         title: 'Invalid Schedule',
@@ -56,3 +102,4 @@ export const useScheduleState = () => {
     validateAndSubmit,
   };
 };
+


### PR DESCRIPTION
 📃 Why Merge This PR?

 Prevents users from scheduling a blog for a past time on the current day. The scheduler now validates that the selected date and time is in the future before sending the scheduling request.



 🛠️ Issue Fixed
  Fixes #627


🔍 PR Type

   - [ ] 💡 Feature
   - [x] 🐛 Bug Fix
   - [ ] 📃 Documentation
   - [ ] 🎨 UI Improvements
   - [ ] 💻 Code Refactor
   - [ ] ✅ Tests


  <table>
  <tr>
    <th>Issue</th>
  </tr>
  <tr>
    <td align="center">
      
<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/71795256-0840-4ebe-a02a-73d8277f6b21" />
  </tr>
  <tr>
    <th>Solution</th>
  </tr>
  <tr>
    <td align="center">
    
<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/bc50bad3-fd97-4e0c-96f2-b45b0cf7501b" />

</tr>


<tr>
    <td align="center">
    
<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/98024669-01f5-4966-aa2c-36e28a1c7eef" />


</tr>
</table>