### PR TITLE
fix: don't run action if PR belongs to fork

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   delete-branch:
-    if: github.event.pull_request.merged == true # Ensures action runs only when merged
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### 📃 Why Merge This PR?

Fixes the-monkeys/the_monkeys#638

The approach is to check if the fork base matches the head of the PR