### PR TITLE
fix: disable future dates for date of birth

### DIFF
--- a/apps/the_monkeys/src/app/settings/components/Profile.tsx
+++ b/apps/the_monkeys/src/app/settings/components/Profile.tsx
@@ -250,6 +250,7 @@ export const Profile = ({ data }: { data?: IUser }) => {
                           captionLayout='dropdown'
                           startMonth={new Date(1960, 0)}
                           endMonth={new Date(new Date().getFullYear(), 11)}
+                          disabled={{ after: new Date() }}
                         />
                       </PopoverContent>
                     </Popover>


### PR DESCRIPTION
### 📃 Why Merge This PR?
   Fixes the Date of Birth picker in Profile settings to prevent users
   from selecting a future date.

   ### 🛠️ Issue Fixed
   Fixes #654

   ### 🔍 PR Type
   - [ ] 💡 Feature
   - [x] 🐛 Bug Fix
   - [ ] 📃 Documentation
   - [ ] 🎨 UI Improvements
   - [ ] 💻 Code Refactor
   - [ ] ✅ Tests