### PR TITLE
Add Open Graph cards for event groups and profiles

### DIFF
--- a/apps/the_monkeys/src/app/[username]/layout.tsx
+++ b/apps/the_monkeys/src/app/[username]/layout.tsx
@@ -59,7 +59,7 @@ export async function generateMetadata({
       };
     }
 
-    const profileImageUrl = `${LIVE_URL}/opengraph-image.png?b7ef6eff2b7766be`;
+    const profileImageUrl = `${LIVE_URL}/social-snapshot-placeholder.png`;
     const fullName = `${userData.first_name} ${userData.last_name ?? ''}`;
     const description =
       userData.bio ||
@@ -87,6 +87,7 @@ export async function generateMetadata({
         title: `${fullName} (@${username})`,
         description: truncateDescription(description, 160),
         url: profileUrl,
+        siteName: 'Monkeys',
         type: 'profile',
         images: [
           {

--- a/apps/the_monkeys/src/app/events/[slug]/page.tsx
+++ b/apps/the_monkeys/src/app/events/[slug]/page.tsx
@@ -29,9 +29,12 @@ export async function generateMetadata({
     return { title: 'Event not found' };
   }
 
+  const base = LIVE_URL || 'https://monkeys.com.co';
   const title = event.title;
   const description = (event.description || '').slice(0, 160);
-  const url = `${LIVE_URL || 'https://monkeys.com.co'}/events/${event.slug}`;
+  const url = `${base}/events/${event.slug}`;
+  const imageUrl =
+    event.cover_image || `${base}/social-snapshot-placeholder.png`;
 
   return {
     title,
@@ -40,13 +43,22 @@ export async function generateMetadata({
       title,
       description,
       url,
+      siteName: 'Monkeys',
       type: 'website',
-      images: event.cover_image ? [{ url: event.cover_image }] : undefined,
+      images: [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
     },
     twitter: {
-      card: event.cover_image ? 'summary_large_image' : 'summary',
+      card: 'summary_large_image',
       title,
       description,
+      images: [imageUrl],
     },
   };
 }
@@ -100,7 +112,9 @@ function buildEventJsonLd(event: NonNullable<EventResp['event']>) {
   };
 
   if (event.description) jsonLd.description = event.description.slice(0, 500);
-  if (event.cover_image) jsonLd.image = [event.cover_image];
+  jsonLd.image = [
+    event.cover_image || `${base}/social-snapshot-placeholder.png`,
+  ];
   if (event.tags?.length) jsonLd.keywords = event.tags.join(', ');
 
   if (event.event_type !== 'virtual' && event.location) {

--- a/apps/the_monkeys/src/app/events/layout.tsx
+++ b/apps/the_monkeys/src/app/events/layout.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from 'next';
 
+import { LIVE_URL } from '@/constants/api';
+
+const base = LIVE_URL || 'https://monkeys.com.co';
+
 export const metadata: Metadata = {
   title: 'Events',
   description:
@@ -8,7 +12,23 @@ export const metadata: Metadata = {
     title: 'Events · Monkeys',
     description:
       'Find talks, meetups, and live sessions from the Monkeys community.',
+    siteName: 'Monkeys',
     type: 'website',
+    images: [
+      {
+        url: `${base}/social-snapshot-placeholder.png`,
+        width: 1200,
+        height: 630,
+        alt: 'Monkeys Events',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Events · Monkeys',
+    description:
+      'Find talks, meetups, and live sessions from the Monkeys community.',
+    images: [`${base}/social-snapshot-placeholder.png`],
   },
 };
 

--- a/apps/the_monkeys/src/app/groups/[slug]/page.tsx
+++ b/apps/the_monkeys/src/app/groups/[slug]/page.tsx
@@ -29,10 +29,14 @@ export async function generateMetadata({
     return { title: 'Group not found' };
   }
 
+  const base = LIVE_URL || 'https://monkeys.com.co';
   const title = group.name;
   const description = (group.description || '').slice(0, 160);
-  const url = `${LIVE_URL || 'https://monkeys.com.co'}/groups/${group.slug}`;
-  const image = group.cover_image || group.logo_image;
+  const url = `${base}/groups/${group.slug}`;
+  const imageUrl =
+    group.cover_image ||
+    group.logo_image ||
+    `${base}/social-snapshot-placeholder.png`;
 
   return {
     title,
@@ -41,13 +45,22 @@ export async function generateMetadata({
       title,
       description,
       url,
+      siteName: 'Monkeys',
       type: 'website',
-      images: image ? [{ url: image }] : undefined,
+      images: [
+        {
+          url: imageUrl,
+          width: 1200,
+          height: 630,
+          alt: title,
+        },
+      ],
     },
     twitter: {
-      card: image ? 'summary_large_image' : 'summary',
+      card: 'summary_large_image',
       title,
       description,
+      images: [imageUrl],
     },
   };
 }

--- a/apps/the_monkeys/src/app/groups/layout.tsx
+++ b/apps/the_monkeys/src/app/groups/layout.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from 'next';
 
+import { LIVE_URL } from '@/constants/api';
+
+const base = LIVE_URL || 'https://monkeys.com.co';
+
 export const metadata: Metadata = {
   title: 'Groups',
   description:
@@ -8,7 +12,23 @@ export const metadata: Metadata = {
     title: 'Groups · Monkeys',
     description:
       'Discover communities, meet organizers, and join groups on the Monkeys platform.',
+    siteName: 'Monkeys',
     type: 'website',
+    images: [
+      {
+        url: `${base}/social-snapshot-placeholder.png`,
+        width: 1200,
+        height: 630,
+        alt: 'Monkeys Groups',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Groups · Monkeys',
+    description:
+      'Discover communities, meet organizers, and join groups on the Monkeys platform.',
+    images: [`${base}/social-snapshot-placeholder.png`],
   },
 };
 


### PR DESCRIPTION
This commit introduces dynamic Open Graph metadata for event group pages and user profile pages. Social platforms will now render rich preview cards with appropriate titles, descriptions, and images when these URLs are shared.

- Implement Open Graph meta tags in event group layout templates

- Add dynamic Open Graph tag generation to user profile views

- Fetch and map relevant group and profile images for preview cards

### 📃 Why Merge This PR?

Briefly describe the changes, fixes, or new features introduced in this PR.

### 🛠️ Issue Fixed

List any issues this PR resolves (e.g., `Fixes #123`).

### 🔍 PR Type

- [ ] 💡 Feature
- [ ] 🐛 Bug Fix
- [ ] 📃 Documentation
- [ ] 🎨 UI Improvements
- [ ] 💻 Code Refactor
- [ ] ✅ Tests
